### PR TITLE
Add authentication and security hardening to Pi web UI

### DIFF
--- a/pi/appliance.py
+++ b/pi/appliance.py
@@ -4,8 +4,10 @@ Reads and writes ~/.printpulse_appliance.json — the bridge between
 the Flask web UI and the systemd watch service.
 """
 
+import hashlib
 import json
 import os
+import secrets
 
 CONFIG_PATH = os.path.expanduser("~/.printpulse_appliance.json")
 
@@ -21,6 +23,9 @@ def default_config() -> dict:
         "theme": "green",
         "printer_device": "/dev/usb/lp0",
         "enabled": True,
+        "auth_user": "",
+        "auth_hash": "",
+        "secret_key": "",
     }
 
 
@@ -40,7 +45,44 @@ def load_config() -> dict:
 
 
 def save_config(data: dict) -> None:
-    """Write appliance config to disk."""
-    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    """Write appliance config to disk with secure permissions."""
+    config_dir = os.path.dirname(CONFIG_PATH)
+    os.makedirs(config_dir, exist_ok=True)
+    # Secure directory permissions (owner only)
+    try:
+        os.chmod(config_dir, 0o700)
+    except OSError:
+        pass
+
     with open(CONFIG_PATH, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
+
+    # Secure file permissions (owner read/write only)
+    try:
+        os.chmod(CONFIG_PATH, 0o600)
+    except OSError:
+        pass
+
+
+def hash_password(password: str) -> str:
+    """Hash a password with a random salt using SHA-256.
+
+    Returns 'salt:hash' string for storage.
+    """
+    salt = secrets.token_hex(16)
+    h = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
+    return f"{salt}:{h}"
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """Verify a password against a stored 'salt:hash' string."""
+    if ":" not in stored_hash:
+        return False
+    salt, expected = stored_hash.split(":", 1)
+    h = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
+    return secrets.compare_digest(h, expected)
+
+
+def generate_secret_key() -> str:
+    """Generate a random secret key for Flask sessions/CSRF."""
+    return secrets.token_hex(32)

--- a/pi/setup.sh
+++ b/pi/setup.sh
@@ -123,18 +123,45 @@ sudo systemctl daemon-reload
 sudo systemctl enable printpulse printpulse-web
 echo "  Services enabled (will start on boot)"
 
-# ── 7. Create default config and start ───────────────────────────
-echo "[7/7] Creating default configuration..."
+# ── 7. Create config and set up web UI credentials ──────────────
+echo "[7/7] Setting up configuration and credentials..."
+echo ""
+echo "  The web UI requires a username and password."
+echo "  You'll use these to log in from your phone/laptop."
+echo ""
+
+# Prompt for web UI credentials
+read -p "  Choose a web UI username: " WEB_USER
+while [ -z "$WEB_USER" ]; do
+    read -p "  Username cannot be empty. Try again: " WEB_USER
+done
+
+read -s -p "  Choose a web UI password: " WEB_PASS
+echo ""
+while [ -z "$WEB_PASS" ]; do
+    read -s -p "  Password cannot be empty. Try again: " WEB_PASS
+    echo ""
+done
+
+# Create config with hashed credentials
 python3 -c "
 import sys
 sys.path.insert(0, '$PP_HOME/PrintPulse')
-from pi.appliance import save_config, default_config, CONFIG_PATH
+from pi.appliance import save_config, load_config, default_config, hash_password, generate_secret_key, CONFIG_PATH
 import os
-if not os.path.isfile(CONFIG_PATH):
-    save_config(default_config())
-    print('  Default config created')
+
+if os.path.isfile(CONFIG_PATH):
+    config = load_config()
+    print('  Existing config found, updating credentials...')
 else:
-    print('  Config already exists, keeping it')
+    config = default_config()
+    print('  Creating new config...')
+
+config['auth_user'] = '$WEB_USER'
+config['auth_hash'] = hash_password('$WEB_PASS')
+config['secret_key'] = generate_secret_key()
+save_config(config)
+print('  Credentials saved (password hashed, not stored in plaintext)')
 "
 
 # Start the services

--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -4,22 +4,155 @@ A lightweight Flask app that lets you configure the PrintPulse
 news watcher from any device on your local network.
 
 Access at http://<pi-ip>:5000
+
+Security features:
+- Basic authentication (username/password set during setup)
+- CSRF tokens on all forms
+- Security headers (CSP, X-Frame-Options, etc.)
+- Rate limiting on sensitive endpoints
 """
 
+import functools
 import os
+import secrets
 import subprocess
 import sys
+import time
 
 # Add project root to path
 _project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if _project_root not in sys.path:
     sys.path.insert(0, _project_root)
 
-from flask import Flask, render_template, request, redirect, url_for, jsonify
-from pi.appliance import load_config, save_config
+from flask import (
+    Flask, render_template, request, redirect, url_for, jsonify,
+    session, abort, g,
+)
+from pi.appliance import load_config, save_config, verify_password
 
 app = Flask(__name__)
 
+# Load secret key from config (generated during setup)
+_cfg = load_config()
+app.secret_key = _cfg.get("secret_key") or secrets.token_hex(32)
+
+
+# ─── Rate Limiting ──────────────────────────────────────────────────────────
+
+_rate_limit_store: dict[str, list[float]] = {}
+RATE_LIMIT_MAX = 10       # max requests
+RATE_LIMIT_WINDOW = 60    # per 60 seconds
+
+
+def _check_rate_limit(key: str) -> bool:
+    """Return True if rate limit exceeded."""
+    now = time.time()
+    if key not in _rate_limit_store:
+        _rate_limit_store[key] = []
+
+    # Remove old entries outside the window
+    _rate_limit_store[key] = [
+        t for t in _rate_limit_store[key] if now - t < RATE_LIMIT_WINDOW
+    ]
+
+    if len(_rate_limit_store[key]) >= RATE_LIMIT_MAX:
+        return True
+
+    _rate_limit_store[key].append(now)
+    return False
+
+
+# ─── Authentication ─────────────────────────────────────────────────────────
+
+def _is_auth_configured() -> bool:
+    """Check if authentication credentials are set."""
+    cfg = load_config()
+    return bool(cfg.get("auth_user")) and bool(cfg.get("auth_hash"))
+
+
+def require_auth(f):
+    """Decorator: require login for protected routes."""
+    @functools.wraps(f)
+    def decorated(*args, **kwargs):
+        if not _is_auth_configured():
+            # No auth configured — allow access (first-run scenario)
+            return f(*args, **kwargs)
+
+        if not session.get("authenticated"):
+            return redirect(url_for("login"))
+
+        return f(*args, **kwargs)
+    return decorated
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    error = None
+    if request.method == "POST":
+        client_ip = request.remote_addr or "unknown"
+        if _check_rate_limit(f"login:{client_ip}"):
+            error = "Too many attempts. Try again in a minute."
+        else:
+            cfg = load_config()
+            username = request.form.get("username", "")
+            password = request.form.get("password", "")
+
+            if (username == cfg.get("auth_user", "")
+                    and verify_password(password, cfg.get("auth_hash", ""))):
+                session["authenticated"] = True
+                return redirect(url_for("index"))
+            else:
+                error = "Invalid credentials."
+
+    return render_template("login.html", error=error)
+
+
+@app.route("/logout")
+def logout():
+    session.pop("authenticated", None)
+    return redirect(url_for("login"))
+
+
+# ─── CSRF Protection ────────────────────────────────────────────────────────
+
+@app.before_request
+def _csrf_protect():
+    """Validate CSRF token on all POST requests."""
+    if request.method == "POST":
+        token = session.get("csrf_token")
+        form_token = request.form.get("csrf_token")
+        if not token or not form_token or not secrets.compare_digest(token, form_token):
+            abort(403)
+
+
+def _generate_csrf_token() -> str:
+    """Generate and store a CSRF token in the session."""
+    if "csrf_token" not in session:
+        session["csrf_token"] = secrets.token_hex(32)
+    return session["csrf_token"]
+
+
+# Make csrf_token available in all templates
+app.jinja_env.globals["csrf_token"] = _generate_csrf_token
+
+
+# ─── Security Headers ───────────────────────────────────────────────────────
+
+@app.after_request
+def _add_security_headers(response):
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline';"
+    )
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    return response
+
+
+# ─── Service Helpers ─────────────────────────────────────────────────────────
 
 def _service_status() -> str:
     """Get the systemd service status (active/inactive/failed)."""
@@ -40,7 +173,10 @@ def _printer_detected() -> bool:
     return os.path.exists(device)
 
 
+# ─── Routes ──────────────────────────────────────────────────────────────────
+
 @app.route("/")
+@require_auth
 def index():
     config = load_config()
     status = _service_status()
@@ -55,7 +191,12 @@ def index():
 
 
 @app.route("/save", methods=["POST"])
+@require_auth
 def save():
+    client_ip = request.remote_addr or "unknown"
+    if _check_rate_limit(f"save:{client_ip}"):
+        abort(429)
+
     feeds_raw = request.form.get("feeds", "").strip()
     feeds = [f.strip() for f in feeds_raw.splitlines() if f.strip()]
 
@@ -80,7 +221,12 @@ def save():
 
 
 @app.route("/start", methods=["POST"])
+@require_auth
 def start():
+    client_ip = request.remote_addr or "unknown"
+    if _check_rate_limit(f"control:{client_ip}"):
+        abort(429)
+
     try:
         subprocess.run(["sudo", "systemctl", "start", "printpulse"], timeout=10)
     except Exception:
@@ -89,7 +235,12 @@ def start():
 
 
 @app.route("/stop", methods=["POST"])
+@require_auth
 def stop():
+    client_ip = request.remote_addr or "unknown"
+    if _check_rate_limit(f"control:{client_ip}"):
+        abort(429)
+
     try:
         subprocess.run(["sudo", "systemctl", "stop", "printpulse"], timeout=10)
     except Exception:
@@ -98,6 +249,7 @@ def stop():
 
 
 @app.route("/status")
+@require_auth
 def status_api():
     """JSON endpoint for live status polling."""
     return jsonify({

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -152,7 +152,10 @@
     </style>
 </head>
 <body>
-    <h1>[ PRINTPULSE ]</h1>
+    <div style="display:flex; justify-content:space-between; align-items:center;">
+        <h1>[ PRINTPULSE ]</h1>
+        <a href="/logout" style="color:#1a4a1a; text-decoration:none; font-size:0.8em;">[ LOGOUT ]</a>
+    </div>
     <div class="subtitle">Appliance Configuration</div>
 
     <!-- Status Bar -->
@@ -173,6 +176,7 @@
 
     <!-- Config Form -->
     <form action="/save" method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <div class="panel">
             <div class="panel-title">// RSS FEEDS</div>
             <label for="feeds">Feed URLs (one per line):</label>
@@ -220,9 +224,11 @@
         <div class="panel-title">// SERVICE CONTROL</div>
         <div class="btn-row">
             <form action="/start" method="post" style="flex:1;display:flex;">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn-start" style="flex:1;">[ START ]</button>
             </form>
             <form action="/stop" method="post" style="flex:1;display:flex;">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn-stop" style="flex:1;">[ STOP ]</button>
             </form>
         </div>

--- a/pi/webapp/templates/login.html
+++ b/pi/webapp/templates/login.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PrintPulse — Login</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            background: #0a0a0a;
+            color: #33ff33;
+            font-family: 'Courier New', monospace;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            padding: 20px;
+        }
+
+        .login-box {
+            border: 2px solid #1a4a1a;
+            padding: 30px;
+            background: #0d0d0d;
+            width: 100%;
+            max-width: 380px;
+        }
+
+        h1 {
+            text-align: center;
+            font-size: 1.4em;
+            margin-bottom: 5px;
+            text-shadow: 0 0 10px #33ff33;
+        }
+
+        .subtitle {
+            text-align: center;
+            color: #1a8a1a;
+            margin-bottom: 25px;
+            font-size: 0.8em;
+        }
+
+        label {
+            display: block;
+            color: #1aaa1a;
+            margin-bottom: 4px;
+            font-size: 0.85em;
+        }
+
+        input {
+            width: 100%;
+            background: #111;
+            color: #33ff33;
+            border: 1px solid #1a4a1a;
+            padding: 10px;
+            font-family: 'Courier New', monospace;
+            font-size: 0.9em;
+            margin-bottom: 15px;
+        }
+
+        input:focus {
+            outline: none;
+            border-color: #33ff33;
+            box-shadow: 0 0 5px #1a4a1a;
+        }
+
+        button {
+            width: 100%;
+            background: #111;
+            color: #33ff33;
+            border: 2px solid #33ff33;
+            padding: 12px;
+            font-family: 'Courier New', monospace;
+            font-size: 1em;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background: #33ff33;
+            color: #0a0a0a;
+        }
+
+        .error {
+            background: #1a0000;
+            border: 1px solid #ff3333;
+            color: #ff3333;
+            padding: 10px;
+            margin-bottom: 15px;
+            font-size: 0.85em;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-box">
+        <h1>[ PRINTPULSE ]</h1>
+        <div class="subtitle">Authentication Required</div>
+
+        {% if error %}
+        <div class="error">{{ error }}</div>
+        {% endif %}
+
+        <form method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <label for="username">Username:</label>
+            <input type="text" name="username" id="username" autocomplete="username" required>
+            <label for="password">Password:</label>
+            <input type="password" name="password" id="password" autocomplete="current-password" required>
+            <button type="submit">[ LOGIN ]</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/tests/test_appliance.py
+++ b/tests/test_appliance.py
@@ -1,0 +1,92 @@
+"""Tests for pi.appliance module — config and credential management."""
+
+import sys
+import os
+
+# Ensure pi/ is importable
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+from pi.appliance import (
+    default_config,
+    hash_password,
+    verify_password,
+    generate_secret_key,
+)
+
+
+class TestDefaultConfig:
+    def test_has_required_keys(self):
+        cfg = default_config()
+        assert "feeds" in cfg
+        assert "interval" in cfg
+        assert "max_prints" in cfg
+        assert "theme" in cfg
+        assert "printer_device" in cfg
+        assert "enabled" in cfg
+
+    def test_has_auth_fields(self):
+        cfg = default_config()
+        assert "auth_user" in cfg
+        assert "auth_hash" in cfg
+        assert "secret_key" in cfg
+
+    def test_auth_fields_empty_by_default(self):
+        cfg = default_config()
+        assert cfg["auth_user"] == ""
+        assert cfg["auth_hash"] == ""
+        assert cfg["secret_key"] == ""
+
+    def test_default_feed_is_https(self):
+        cfg = default_config()
+        for feed in cfg["feeds"]:
+            assert feed.startswith("https://")
+
+
+class TestPasswordHashing:
+    def test_hash_produces_salt_colon_hash(self):
+        result = hash_password("test123")
+        assert ":" in result
+        parts = result.split(":", 1)
+        assert len(parts) == 2
+        assert len(parts[0]) == 32  # 16 bytes hex = 32 chars
+        assert len(parts[1]) == 64  # SHA-256 hex = 64 chars
+
+    def test_verify_correct_password(self):
+        hashed = hash_password("mypassword")
+        assert verify_password("mypassword", hashed) is True
+
+    def test_verify_wrong_password(self):
+        hashed = hash_password("mypassword")
+        assert verify_password("wrongpassword", hashed) is False
+
+    def test_verify_empty_hash(self):
+        assert verify_password("test", "") is False
+
+    def test_verify_malformed_hash(self):
+        assert verify_password("test", "nocolonhere") is False
+
+    def test_different_hashes_for_same_password(self):
+        # Salt should make each hash unique
+        h1 = hash_password("same")
+        h2 = hash_password("same")
+        assert h1 != h2
+
+    def test_both_still_verify(self):
+        h1 = hash_password("same")
+        h2 = hash_password("same")
+        assert verify_password("same", h1) is True
+        assert verify_password("same", h2) is True
+
+
+class TestSecretKey:
+    def test_generates_string(self):
+        key = generate_secret_key()
+        assert isinstance(key, str)
+        assert len(key) == 64  # 32 bytes hex = 64 chars
+
+    def test_unique_each_time(self):
+        k1 = generate_secret_key()
+        k2 = generate_secret_key()
+        assert k1 != k2


### PR DESCRIPTION
## Summary
Fixes #1 — Adds comprehensive security to the Pi appliance web configuration UI.

- **Basic auth**: Login required with username/password (set during `setup.sh`). Passwords stored as salted SHA-256 hashes, never plaintext.
- **CSRF protection**: All POST forms include and validate a CSRF token.
- **Security headers**: CSP, X-Frame-Options DENY, X-Content-Type-Options nosniff, X-XSS-Protection, Referrer-Policy.
- **Rate limiting**: 10 requests/minute per IP on login, save, and service control endpoints.
- **Secure config**: Config file permissions set to `0o600`, directory to `0o700`.
- **Setup flow**: `setup.sh` now prompts for web UI credentials during installation.

## Test plan
- [x] 13 new tests for password hashing, verification, secret key generation, config structure
- [x] All 55 tests passing locally
- [ ] CI passes on this PR
- [ ] Manual test: login page blocks unauthenticated access
- [ ] Manual test: CSRF token rejection on forged POST
- [ ] Manual test: rate limiting triggers after 10 rapid requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)