### PR TITLE
Validate all user inputs in Pi web UI

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -10,14 +10,18 @@ Security features:
 - CSRF tokens on all forms
 - Security headers (CSP, X-Frame-Options, etc.)
 - Rate limiting on sensitive endpoints
+- Input validation on all user-submitted data
 """
 
 import functools
+import ipaddress
 import os
+import re
 import secrets
 import subprocess
 import sys
 import time
+from urllib.parse import urlparse
 
 # Add project root to path
 _project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -152,6 +156,138 @@ def _add_security_headers(response):
     return response
 
 
+# ─── Input Validation ────────────────────────────────────────────────────────
+
+# Allowed printer device patterns (whitelist)
+_DEVICE_PATTERN = re.compile(r"^/dev/(usb/lp|ttyUSB|ttyACM)\d+$")
+
+# Allowed themes
+_VALID_THEMES = {"green", "amber"}
+
+# Feed limits
+_MAX_FEEDS = 20
+_MAX_FEED_URL_LEN = 2048
+
+# Private/reserved IP ranges to block in feed URLs (SSRF prevention)
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _is_private_hostname(hostname: str) -> bool:
+    """Check if a hostname resolves to a private/reserved IP."""
+    # Block obvious localhost aliases
+    if hostname.lower() in ("localhost", "localhost.localdomain", "0.0.0.0"):
+        return True
+
+    # Check if hostname is a raw IP address in a private range
+    try:
+        addr = ipaddress.ip_address(hostname)
+        return any(addr in net for net in _PRIVATE_NETWORKS)
+    except ValueError:
+        pass  # Not a raw IP, could be a domain name — allow it
+
+    return False
+
+
+def validate_save_input(form) -> tuple[dict | None, list[str]]:
+    """Validate all fields from the /save form.
+
+    Returns (parsed_data, errors) where parsed_data is None if
+    there are validation errors.
+    """
+    errors: list[str] = []
+
+    # --- Feeds ---
+    feeds_raw = form.get("feeds", "").strip()
+    feeds = [f.strip() for f in feeds_raw.splitlines() if f.strip()]
+
+    if len(feeds) > _MAX_FEEDS:
+        errors.append(f"Too many feeds (max {_MAX_FEEDS}).")
+        feeds = feeds[:_MAX_FEEDS]
+
+    validated_feeds = []
+    for url in feeds:
+        if len(url) > _MAX_FEED_URL_LEN:
+            errors.append(f"Feed URL too long (max {_MAX_FEED_URL_LEN} chars): {url[:60]}...")
+            continue
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            errors.append(f"Feed URL must use http:// or https://: {url[:60]}")
+            continue
+        if not parsed.hostname:
+            errors.append(f"Feed URL has no hostname: {url[:60]}")
+            continue
+        if _is_private_hostname(parsed.hostname):
+            errors.append(f"Feed URL points to a private/local address: {url[:60]}")
+            continue
+        validated_feeds.append(url)
+
+    # --- Interval ---
+    try:
+        interval = int(form.get("interval", 300))
+    except (ValueError, TypeError):
+        errors.append("Poll interval must be a number.")
+        interval = 300
+
+    if interval < 60:
+        errors.append("Poll interval must be at least 60 seconds.")
+        interval = 60
+    elif interval > 3600:
+        errors.append("Poll interval must be at most 3600 seconds.")
+        interval = 3600
+
+    # --- Max prints ---
+    try:
+        max_prints = int(form.get("max_prints", 3))
+    except (ValueError, TypeError):
+        errors.append("Max prints must be a number.")
+        max_prints = 3
+
+    if max_prints < 1:
+        errors.append("Max prints must be at least 1.")
+        max_prints = 1
+    elif max_prints > 20:
+        errors.append("Max prints must be at most 20.")
+        max_prints = 20
+
+    # --- Theme ---
+    theme = form.get("theme", "green")
+    if theme not in _VALID_THEMES:
+        errors.append(f"Invalid theme. Must be one of: {', '.join(sorted(_VALID_THEMES))}.")
+        theme = "green"
+
+    # --- Printer device ---
+    printer_device = form.get("printer_device", "/dev/usb/lp0").strip()
+    if len(printer_device) > 64:
+        errors.append("Printer device path too long.")
+        printer_device = "/dev/usb/lp0"
+    elif not _DEVICE_PATTERN.match(printer_device):
+        errors.append(
+            "Invalid printer device. Must match /dev/usb/lp*, "
+            "/dev/ttyUSB*, or /dev/ttyACM*."
+        )
+        printer_device = "/dev/usb/lp0"
+
+    if errors:
+        return None, errors
+
+    return {
+        "feeds": validated_feeds,
+        "interval": interval,
+        "max_prints": max_prints,
+        "theme": theme,
+        "printer_device": printer_device,
+    }, []
+
+
 # ─── Service Helpers ─────────────────────────────────────────────────────────
 
 def _service_status() -> str:
@@ -187,6 +323,7 @@ def index():
         status=status,
         printer_ok=printer_ok,
         feeds_text="\n".join(config.get("feeds", [])),
+        errors=[],
     )
 
 
@@ -197,15 +334,28 @@ def save():
     if _check_rate_limit(f"save:{client_ip}"):
         abort(429)
 
-    feeds_raw = request.form.get("feeds", "").strip()
-    feeds = [f.strip() for f in feeds_raw.splitlines() if f.strip()]
+    validated, errors = validate_save_input(request.form)
+
+    if errors:
+        # Re-render the page with error messages and submitted values
+        config = load_config()
+        status = _service_status()
+        printer_ok = _printer_detected()
+        return render_template(
+            "index.html",
+            config=config,
+            status=status,
+            printer_ok=printer_ok,
+            feeds_text=request.form.get("feeds", ""),
+            errors=errors,
+        )
 
     config = load_config()
-    config["feeds"] = feeds
-    config["interval"] = int(request.form.get("interval", 300))
-    config["max_prints"] = int(request.form.get("max_prints", 3))
-    config["theme"] = request.form.get("theme", "green")
-    config["printer_device"] = request.form.get("printer_device", "/dev/usb/lp0")
+    config["feeds"] = validated["feeds"]
+    config["interval"] = validated["interval"]
+    config["max_prints"] = validated["max_prints"]
+    config["theme"] = validated["theme"]
+    config["printer_device"] = validated["printer_device"]
     save_config(config)
 
     # Restart the watcher service to pick up new config

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -174,6 +174,16 @@
         </div>
     </div>
 
+    <!-- Validation Errors -->
+    {% if errors %}
+    <div class="panel" style="border-color: #ff3333; margin-bottom: 20px;">
+        <div class="panel-title" style="color: #ff3333; border-bottom-color: #ff3333;">// VALIDATION ERRORS</div>
+        {% for err in errors %}
+        <div style="color: #ff3333; font-size: 0.85em; margin-bottom: 4px;">&gt; {{ err }}</div>
+        {% endfor %}
+    </div>
+    {% endif %}
+
     <!-- Config Form -->
     <form action="/save" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,258 @@
+"""Tests for input validation in the Pi web UI."""
+
+import sys
+import os
+
+# Ensure pi/ is importable
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+from pi.webapp.server import validate_save_input, _is_private_hostname
+
+
+class FakeForm(dict):
+    """Mimic Flask's request.form (a MultiDict)."""
+    def get(self, key, default=None):
+        return super().get(key, default)
+
+
+# ─── Feed URL Validation ────────────────────────────────────────────────────
+
+
+class TestFeedValidation:
+    def _form(self, feeds="", **kw):
+        return FakeForm(
+            feeds=feeds,
+            interval=kw.get("interval", "300"),
+            max_prints=kw.get("max_prints", "3"),
+            theme=kw.get("theme", "green"),
+            printer_device=kw.get("printer_device", "/dev/usb/lp0"),
+        )
+
+    def test_valid_https_feed(self):
+        data, errors = validate_save_input(self._form(
+            feeds="https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml"
+        ))
+        assert not errors
+        assert len(data["feeds"]) == 1
+
+    def test_valid_http_feed_allowed(self):
+        data, errors = validate_save_input(self._form(
+            feeds="http://feeds.bbci.co.uk/news/rss.xml"
+        ))
+        assert not errors
+        assert len(data["feeds"]) == 1
+
+    def test_rejects_file_scheme(self):
+        _, errors = validate_save_input(self._form(
+            feeds="file:///etc/passwd"
+        ))
+        assert any("http" in e.lower() or "https" in e.lower() for e in errors)
+
+    def test_rejects_ftp_scheme(self):
+        _, errors = validate_save_input(self._form(
+            feeds="ftp://example.com/feed.xml"
+        ))
+        assert len(errors) > 0
+
+    def test_rejects_localhost(self):
+        _, errors = validate_save_input(self._form(
+            feeds="http://localhost/secret"
+        ))
+        assert any("private" in e.lower() or "local" in e.lower() for e in errors)
+
+    def test_rejects_private_ip(self):
+        _, errors = validate_save_input(self._form(
+            feeds="http://192.168.1.1/feed"
+        ))
+        assert any("private" in e.lower() or "local" in e.lower() for e in errors)
+
+    def test_rejects_link_local(self):
+        _, errors = validate_save_input(self._form(
+            feeds="http://169.254.169.254/metadata"
+        ))
+        assert len(errors) > 0
+
+    def test_rejects_loopback_ip(self):
+        _, errors = validate_save_input(self._form(
+            feeds="http://127.0.0.1/admin"
+        ))
+        assert len(errors) > 0
+
+    def test_too_many_feeds(self):
+        feeds = "\n".join(f"https://example.com/feed{i}.xml" for i in range(25))
+        _, errors = validate_save_input(self._form(feeds=feeds))
+        assert any("too many" in e.lower() for e in errors)
+
+    def test_feed_url_too_long(self):
+        url = "https://example.com/" + "a" * 2100
+        _, errors = validate_save_input(self._form(feeds=url))
+        assert any("too long" in e.lower() for e in errors)
+
+    def test_empty_feeds_ok(self):
+        data, errors = validate_save_input(self._form(feeds=""))
+        assert not errors
+        assert data["feeds"] == []
+
+    def test_multiple_valid_feeds(self):
+        feeds = "https://a.com/feed\nhttps://b.com/feed\nhttps://c.com/feed"
+        data, errors = validate_save_input(self._form(feeds=feeds))
+        assert not errors
+        assert len(data["feeds"]) == 3
+
+
+# ─── Integer Field Validation ───────────────────────────────────────────────
+
+
+class TestIntegerValidation:
+    def _form(self, **kw):
+        defaults = {
+            "feeds": "",
+            "interval": "300",
+            "max_prints": "3",
+            "theme": "green",
+            "printer_device": "/dev/usb/lp0",
+        }
+        defaults.update(kw)
+        return FakeForm(defaults)
+
+    def test_valid_interval(self):
+        data, errors = validate_save_input(self._form(interval="120"))
+        assert not errors
+        assert data["interval"] == 120
+
+    def test_interval_too_low(self):
+        _, errors = validate_save_input(self._form(interval="10"))
+        assert any("60" in e for e in errors)
+
+    def test_interval_too_high(self):
+        _, errors = validate_save_input(self._form(interval="9999"))
+        assert any("3600" in e for e in errors)
+
+    def test_interval_not_a_number(self):
+        _, errors = validate_save_input(self._form(interval="abc"))
+        assert any("number" in e.lower() for e in errors)
+
+    def test_max_prints_valid(self):
+        data, errors = validate_save_input(self._form(max_prints="10"))
+        assert not errors
+        assert data["max_prints"] == 10
+
+    def test_max_prints_too_low(self):
+        _, errors = validate_save_input(self._form(max_prints="0"))
+        assert any("1" in e for e in errors)
+
+    def test_max_prints_too_high(self):
+        _, errors = validate_save_input(self._form(max_prints="100"))
+        assert any("20" in e for e in errors)
+
+    def test_max_prints_not_a_number(self):
+        _, errors = validate_save_input(self._form(max_prints="xyz"))
+        assert any("number" in e.lower() for e in errors)
+
+
+# ─── Theme Validation ───────────────────────────────────────────────────────
+
+
+class TestThemeValidation:
+    def _form(self, theme="green"):
+        return FakeForm(
+            feeds="", interval="300", max_prints="3",
+            theme=theme, printer_device="/dev/usb/lp0",
+        )
+
+    def test_green_valid(self):
+        data, errors = validate_save_input(self._form("green"))
+        assert not errors
+        assert data["theme"] == "green"
+
+    def test_amber_valid(self):
+        data, errors = validate_save_input(self._form("amber"))
+        assert not errors
+        assert data["theme"] == "amber"
+
+    def test_invalid_theme_rejected(self):
+        _, errors = validate_save_input(self._form("hacker"))
+        assert any("theme" in e.lower() for e in errors)
+
+    def test_script_injection_rejected(self):
+        _, errors = validate_save_input(self._form("<script>alert(1)</script>"))
+        assert len(errors) > 0
+
+
+# ─── Printer Device Validation ──────────────────────────────────────────────
+
+
+class TestPrinterDeviceValidation:
+    def _form(self, device="/dev/usb/lp0"):
+        return FakeForm(
+            feeds="", interval="300", max_prints="3",
+            theme="green", printer_device=device,
+        )
+
+    def test_lp0_valid(self):
+        data, errors = validate_save_input(self._form("/dev/usb/lp0"))
+        assert not errors
+        assert data["printer_device"] == "/dev/usb/lp0"
+
+    def test_lp1_valid(self):
+        data, errors = validate_save_input(self._form("/dev/usb/lp1"))
+        assert not errors
+
+    def test_ttyUSB0_valid(self):
+        data, errors = validate_save_input(self._form("/dev/ttyUSB0"))
+        assert not errors
+
+    def test_ttyACM0_valid(self):
+        data, errors = validate_save_input(self._form("/dev/ttyACM0"))
+        assert not errors
+
+    def test_rejects_path_traversal(self):
+        _, errors = validate_save_input(self._form("/dev/../../etc/passwd"))
+        assert len(errors) > 0
+
+    def test_rejects_etc_passwd(self):
+        _, errors = validate_save_input(self._form("/etc/passwd"))
+        assert len(errors) > 0
+
+    def test_rejects_dev_sda(self):
+        _, errors = validate_save_input(self._form("/dev/sda"))
+        assert len(errors) > 0
+
+    def test_rejects_arbitrary_path(self):
+        _, errors = validate_save_input(self._form("/tmp/evil"))
+        assert len(errors) > 0
+
+    def test_rejects_too_long_path(self):
+        _, errors = validate_save_input(self._form("/dev/usb/lp" + "0" * 100))
+        assert len(errors) > 0
+
+
+# ─── Private Hostname Detection ─────────────────────────────────────────────
+
+
+class TestPrivateHostname:
+    def test_localhost_is_private(self):
+        assert _is_private_hostname("localhost") is True
+
+    def test_127_0_0_1_is_private(self):
+        assert _is_private_hostname("127.0.0.1") is True
+
+    def test_192_168_is_private(self):
+        assert _is_private_hostname("192.168.1.1") is True
+
+    def test_10_x_is_private(self):
+        assert _is_private_hostname("10.0.0.1") is True
+
+    def test_169_254_is_private(self):
+        assert _is_private_hostname("169.254.169.254") is True
+
+    def test_public_ip_is_not_private(self):
+        assert _is_private_hostname("8.8.8.8") is False
+
+    def test_domain_is_not_private(self):
+        assert _is_private_hostname("example.com") is False
+
+    def test_zero_addr_is_private(self):
+        assert _is_private_hostname("0.0.0.0") is True


### PR DESCRIPTION
## Summary
- **Feed URLs**: Require `http://` or `https://` scheme, block `file://`/`ftp://`, reject private IPs (127.x, 10.x, 192.168.x, 169.254.x, localhost) to prevent SSRF attacks
- **Printer device path**: Whitelist only `/dev/usb/lp*`, `/dev/ttyUSB*`, `/dev/ttyACM*` — blocks path traversal like `/dev/../../etc/passwd`
- **Integer fields**: Enforce bounds (interval: 60–3600s, max_prints: 1–20), reject non-numeric input
- **Theme**: Whitelist `green` and `amber` only — rejects injection payloads
- **Length limits**: Max 20 feeds, max 2048 chars per URL, max 64 chars for device path
- **Error display**: Validation errors shown in retro terminal style on the config page
- **41 new tests** covering all validation rules

Fixes #2

## Test plan
- [x] All 41 validation tests pass locally
- [x] Ruff lint passes
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)