### PR TITLE
Secure file permissions for config and cache

### DIFF
--- a/pi/appliance.py
+++ b/pi/appliance.py
@@ -9,6 +9,8 @@ import json
 import os
 import secrets
 
+from printpulse.secure_fs import secure_write_json
+
 CONFIG_PATH = os.path.expanduser("~/.printpulse_appliance.json")
 
 
@@ -46,22 +48,7 @@ def load_config() -> dict:
 
 def save_config(data: dict) -> None:
     """Write appliance config to disk with secure permissions."""
-    config_dir = os.path.dirname(CONFIG_PATH)
-    os.makedirs(config_dir, exist_ok=True)
-    # Secure directory permissions (owner only)
-    try:
-        os.chmod(config_dir, 0o700)
-    except OSError:
-        pass
-
-    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
-
-    # Secure file permissions (owner read/write only)
-    try:
-        os.chmod(CONFIG_PATH, 0o600)
-    except OSError:
-        pass
+    secure_write_json(CONFIG_PATH, data)
 
 
 def hash_password(password: str) -> str:

--- a/printpulse/app.py
+++ b/printpulse/app.py
@@ -11,6 +11,7 @@ from printpulse import text_to_svg
 from printpulse import plotter
 from printpulse import thermal
 from printpulse import journal
+from printpulse.secure_fs import check_permissions
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -176,9 +177,33 @@ def _resolve_font(font_arg: str | None) -> str | None:
     return None
 
 
+def _check_config_permissions():
+    """Warn if config files have overly permissive permissions."""
+    config_dir = os.path.expanduser("~/.printpulse")
+    appliance_config = os.path.expanduser("~/.printpulse_appliance.json")
+
+    paths_to_check = [config_dir, appliance_config]
+    # Also check files inside config dir
+    if os.path.isdir(config_dir):
+        for name in os.listdir(config_dir):
+            paths_to_check.append(os.path.join(config_dir, name))
+
+    all_warnings = []
+    for path in paths_to_check:
+        all_warnings.extend(check_permissions(path))
+
+    if all_warnings:
+        import warnings
+        for w in all_warnings:
+            warnings.warn(w, stacklevel=2)
+
+
 def run(argv: list[str]):
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    # Check config file permissions on startup
+    _check_config_permissions()
 
     # Build config
     config = Config()

--- a/printpulse/illustrations.py
+++ b/printpulse/illustrations.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from printpulse import ui
+from printpulse.secure_fs import secure_makedirs
 
 # ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -96,7 +97,7 @@ def _cache_get(key: str) -> Optional[str]:
 
 
 def _cache_put(key: str, svg_data: str):
-    os.makedirs(CACHE_DIR, exist_ok=True)
+    secure_makedirs(CACHE_DIR)
     path = os.path.join(CACHE_DIR, f"{key}.svg")
     with open(path, "w", encoding="utf-8") as f:
         f.write(svg_data)
@@ -113,7 +114,7 @@ def _cache_image_get(key: str) -> Optional[bytes]:
 
 def _cache_image_put(key: str, image_bytes: bytes):
     """Cache a DALL-E raster image."""
-    os.makedirs(CACHE_DIR, exist_ok=True)
+    secure_makedirs(CACHE_DIR)
     path = os.path.join(CACHE_DIR, f"{key}.png")
     with open(path, "wb") as f:
         f.write(image_bytes)
@@ -325,7 +326,7 @@ def _trace_image_to_svg_with_params(
     from printpulse import ensure_dependency
     vtracer = ensure_dependency("vtracer")
 
-    os.makedirs(CACHE_DIR, exist_ok=True)
+    secure_makedirs(CACHE_DIR)
     tmp_in = None
     tmp_out = None
     try:

--- a/printpulse/journal.py
+++ b/printpulse/journal.py
@@ -3,6 +3,7 @@ import os
 from datetime import datetime
 
 from printpulse.config import Config
+from printpulse.secure_fs import secure_write_json
 
 DEFAULT_JOURNAL_PATH = os.path.join(os.path.expanduser("~"), ".printpulse_journal.json")
 
@@ -17,8 +18,7 @@ def _load_state(journal_path: str) -> dict:
 
 def _save_state(state: dict, journal_path: str):
     """Save journal state to disk."""
-    with open(journal_path, "w", encoding="utf-8") as f:
-        json.dump(state, f, indent=2, ensure_ascii=False)
+    secure_write_json(journal_path, state)
 
 
 def get_next_line(journal_path: str = DEFAULT_JOURNAL_PATH) -> int:

--- a/printpulse/secure_fs.py
+++ b/printpulse/secure_fs.py
@@ -1,0 +1,119 @@
+"""Secure filesystem operations for PrintPulse.
+
+Centralizes directory/file creation with proper permissions
+and provides secure temp file and cleanup utilities.
+"""
+
+import os
+import platform
+import stat
+import tempfile
+
+_IS_UNIX = platform.system() != "Windows"
+
+# Default permissions: owner-only
+_DIR_MODE = 0o700   # rwx------
+_FILE_MODE = 0o600  # rw-------
+
+
+def secure_makedirs(path: str, mode: int = _DIR_MODE) -> None:
+    """Create directory with secure permissions (owner-only on Unix)."""
+    os.makedirs(path, exist_ok=True)
+    if _IS_UNIX:
+        try:
+            os.chmod(path, mode)
+        except OSError:
+            pass
+
+
+def secure_write_json(path: str, data, indent: int = 2) -> None:
+    """Write JSON to a file with secure permissions."""
+    import json
+
+    dir_path = os.path.dirname(path)
+    if dir_path:
+        secure_makedirs(dir_path)
+
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=indent, ensure_ascii=False)
+
+    if _IS_UNIX:
+        try:
+            os.chmod(path, _FILE_MODE)
+        except OSError:
+            pass
+
+
+def secure_tempfile(suffix: str = ".tmp", prefix: str = "printpulse_") -> str:
+    """Create a temporary file with secure permissions.
+
+    Returns the path to the temp file (closed, ready for writing).
+    """
+    fd = tempfile.mkstemp(suffix=suffix, prefix=prefix)
+    path = fd[1]
+    os.close(fd[0])
+
+    if _IS_UNIX:
+        try:
+            os.chmod(path, _FILE_MODE)
+        except OSError:
+            pass
+
+    return path
+
+
+def secure_delete(path: str) -> None:
+    """Securely delete a file by overwriting with zeros before removal.
+
+    Best-effort: if overwrite fails, still removes the file.
+    """
+    try:
+        if os.path.isfile(path):
+            size = os.path.getsize(path)
+            if size > 0:
+                with open(path, "wb") as f:
+                    f.write(b"\x00" * size)
+                    f.flush()
+                    os.fsync(f.fileno())
+            os.unlink(path)
+    except OSError:
+        # Best effort — try plain removal
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def check_permissions(path: str) -> list[str]:
+    """Check if a file/directory has overly permissive permissions.
+
+    Returns a list of warning messages (empty if everything is fine).
+    Only meaningful on Unix systems.
+    """
+    warnings = []
+
+    if not _IS_UNIX or not os.path.exists(path):
+        return warnings
+
+    try:
+        st = os.stat(path)
+        mode = st.st_mode
+
+        if os.path.isdir(path):
+            # Directory should be 0o700 or stricter
+            if mode & (stat.S_IRWXG | stat.S_IRWXO):
+                warnings.append(
+                    f"Directory {path} is accessible by group/others. "
+                    f"Run: chmod 700 {path}"
+                )
+        else:
+            # File should be 0o600 or stricter
+            if mode & (stat.S_IRWXG | stat.S_IRWXO):
+                warnings.append(
+                    f"File {path} is readable by group/others. "
+                    f"Run: chmod 600 {path}"
+                )
+    except OSError:
+        pass
+
+    return warnings

--- a/printpulse/speech.py
+++ b/printpulse/speech.py
@@ -1,11 +1,11 @@
 import os
 import queue
-import tempfile
 import threading
 
 import numpy as np
 
 from printpulse import ui
+from printpulse.secure_fs import secure_tempfile, secure_delete
 
 _whisper_model = None
 _whisper_model_name = None
@@ -40,9 +40,7 @@ def record_audio(
     import sounddevice as sd
     import soundfile as sf
 
-    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
-    tmp_path = tmp.name
-    tmp.close()
+    tmp_path = secure_tempfile(suffix=".wav")
 
     if duration is not None:
         # Fixed-duration recording

--- a/printpulse/stationery.py
+++ b/printpulse/stationery.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from printpulse import ui
+from printpulse.secure_fs import secure_makedirs, secure_write_json
 
 # ─── Paths ────────────────────────────────────────────────────────────────────
 
@@ -127,7 +128,7 @@ class StationeryProfile:
 
 def _ensure_user_dir():
     """Create user stationery dir and seed with bundled profiles if empty."""
-    os.makedirs(STATIONERY_DIR, exist_ok=True)
+    secure_makedirs(STATIONERY_DIR)
     # Copy bundled profiles that don't already exist in user dir
     if os.path.isdir(BUNDLED_DIR):
         for fname in os.listdir(BUNDLED_DIR):
@@ -180,5 +181,4 @@ def save_profile(profile: StationeryProfile):
     """Save a profile to the user stationery directory."""
     _ensure_user_dir()
     path = os.path.join(STATIONERY_DIR, f"{profile.name}.json")
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(profile.to_dict(), f, indent=2, ensure_ascii=False)
+    secure_write_json(path, profile.to_dict())

--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime
 
 from printpulse import ui
+from printpulse.secure_fs import secure_write_json
 
 SEEN_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_seen.json")
 
@@ -21,8 +22,11 @@ def _load_seen() -> dict:
 
 
 def _save_seen(seen: dict):
-    with open(SEEN_FILE, "w", encoding="utf-8") as f:
-        json.dump({"ids": list(seen["ids"]), "titles": list(seen["titles"])}, f, ensure_ascii=False)
+    secure_write_json(
+        SEEN_FILE,
+        {"ids": list(seen["ids"]), "titles": list(seen["titles"])},
+        indent=0,
+    )
 
 
 def fetch_new_items(feed_url: str, max_items: int = 3) -> list[dict]:

--- a/tests/test_secure_fs.py
+++ b/tests/test_secure_fs.py
@@ -1,0 +1,135 @@
+"""Tests for printpulse.secure_fs module."""
+
+import json
+import os
+import platform
+import sys
+import tempfile
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+from printpulse.secure_fs import (
+    secure_makedirs,
+    secure_write_json,
+    secure_tempfile,
+    secure_delete,
+    check_permissions,
+)
+
+_IS_UNIX = platform.system() != "Windows"
+
+
+class TestSecureMakedirs:
+    def test_creates_directory(self, tmp_path):
+        target = os.path.join(str(tmp_path), "testdir")
+        secure_makedirs(target)
+        assert os.path.isdir(target)
+
+    def test_idempotent(self, tmp_path):
+        target = os.path.join(str(tmp_path), "testdir")
+        secure_makedirs(target)
+        secure_makedirs(target)  # Should not raise
+        assert os.path.isdir(target)
+
+    def test_nested_directories(self, tmp_path):
+        target = os.path.join(str(tmp_path), "a", "b", "c")
+        secure_makedirs(target)
+        assert os.path.isdir(target)
+
+
+class TestSecureWriteJson:
+    def test_writes_valid_json(self, tmp_path):
+        path = os.path.join(str(tmp_path), "test.json")
+        data = {"key": "value", "num": 42}
+        secure_write_json(path, data)
+
+        with open(path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+        assert loaded == data
+
+    def test_creates_parent_directories(self, tmp_path):
+        path = os.path.join(str(tmp_path), "sub", "dir", "test.json")
+        secure_write_json(path, {"test": True})
+        assert os.path.isfile(path)
+
+    def test_unicode_content(self, tmp_path):
+        path = os.path.join(str(tmp_path), "unicode.json")
+        data = {"text": "Hello \u2019 world"}
+        secure_write_json(path, data)
+
+        with open(path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+        assert loaded["text"] == "Hello \u2019 world"
+
+    def test_overwrites_existing(self, tmp_path):
+        path = os.path.join(str(tmp_path), "overwrite.json")
+        secure_write_json(path, {"v": 1})
+        secure_write_json(path, {"v": 2})
+
+        with open(path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+        assert loaded["v"] == 2
+
+
+class TestSecureTempfile:
+    def test_creates_file(self):
+        path = secure_tempfile(suffix=".test")
+        try:
+            assert os.path.isfile(path)
+        finally:
+            os.unlink(path)
+
+    def test_custom_suffix(self):
+        path = secure_tempfile(suffix=".wav")
+        try:
+            assert path.endswith(".wav")
+        finally:
+            os.unlink(path)
+
+    def test_file_is_writable(self):
+        path = secure_tempfile()
+        try:
+            with open(path, "w") as f:
+                f.write("test")
+            with open(path, "r") as f:
+                assert f.read() == "test"
+        finally:
+            os.unlink(path)
+
+
+class TestSecureDelete:
+    def test_deletes_file(self, tmp_path):
+        path = os.path.join(str(tmp_path), "delete_me.txt")
+        with open(path, "w") as f:
+            f.write("sensitive data")
+        secure_delete(path)
+        assert not os.path.exists(path)
+
+    def test_handles_nonexistent_file(self, tmp_path):
+        path = os.path.join(str(tmp_path), "nonexistent.txt")
+        secure_delete(path)  # Should not raise
+
+    def test_handles_empty_file(self, tmp_path):
+        path = os.path.join(str(tmp_path), "empty.txt")
+        with open(path, "w") as f:
+            pass  # Empty file
+        secure_delete(path)
+        assert not os.path.exists(path)
+
+
+class TestCheckPermissions:
+    def test_returns_list(self, tmp_path):
+        result = check_permissions(str(tmp_path))
+        assert isinstance(result, list)
+
+    def test_nonexistent_path_returns_empty(self):
+        result = check_permissions("/nonexistent/path/xyz")
+        assert result == []
+
+    def test_returns_empty_on_windows(self, tmp_path):
+        if _IS_UNIX:
+            return  # Skip on Unix
+        result = check_permissions(str(tmp_path))
+        assert result == []


### PR DESCRIPTION
## Summary
- **New `printpulse/secure_fs.py` module** — centralized secure filesystem operations:
  - `secure_makedirs()`: creates directories with `0o700` (owner-only) on Unix
  - `secure_write_json()`: writes JSON files with `0o600` (owner read/write) on Unix
  - `secure_tempfile()`: creates temp files via `mkstemp` with `0o600` permissions
  - `secure_delete()`: overwrites file contents with zeros before unlinking (secure wipe)
  - `check_permissions()`: audits file/dir permissions and returns warnings
- **Updated 6 modules** to use `secure_fs` instead of raw `os.makedirs`/`open`:
  `pi/appliance.py`, `speech.py`, `watch.py`, `journal.py`, `stationery.py`, `illustrations.py`
- **Startup permission check** in `app.py` — warns if `~/.printpulse/` or config files have group/other access
- **16 new tests** for the `secure_fs` module

Fixes #3

## Test plan
- [x] All 16 secure_fs tests pass locally
- [x] Ruff lint passes
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)