### PR TITLE
Sanitize error messages and add structured logging

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -15,6 +15,7 @@ Security features:
 
 import functools
 import ipaddress
+import logging
 import os
 import re
 import secrets
@@ -22,6 +23,8 @@ import subprocess
 import sys
 import time
 from urllib.parse import urlparse
+
+logger = logging.getLogger("printpulse.webapp")
 
 # Add project root to path
 _project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -298,7 +301,8 @@ def _service_status() -> str:
             capture_output=True, text=True, timeout=5,
         )
         return result.stdout.strip()
-    except Exception:
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("Failed to check service status: %s", type(exc).__name__)
         return "unknown"
 
 
@@ -364,8 +368,9 @@ def save():
             ["sudo", "systemctl", "restart", "printpulse"],
             timeout=10,
         )
-    except Exception:
-        pass
+        logger.info("Config saved and watcher service restarted.")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("Failed to restart watcher service: %s", type(exc).__name__)
 
     return redirect(url_for("index"))
 
@@ -379,8 +384,9 @@ def start():
 
     try:
         subprocess.run(["sudo", "systemctl", "start", "printpulse"], timeout=10)
-    except Exception:
-        pass
+        logger.info("Watcher service started.")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("Failed to start watcher service: %s", type(exc).__name__)
     return redirect(url_for("index"))
 
 
@@ -393,8 +399,9 @@ def stop():
 
     try:
         subprocess.run(["sudo", "systemctl", "stop", "printpulse"], timeout=10)
-    except Exception:
-        pass
+        logger.info("Watcher service stopped.")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("Failed to stop watcher service: %s", type(exc).__name__)
     return redirect(url_for("index"))
 
 

--- a/printpulse/app.py
+++ b/printpulse/app.py
@@ -12,6 +12,7 @@ from printpulse import plotter
 from printpulse import thermal
 from printpulse import journal
 from printpulse.secure_fs import check_permissions
+from printpulse.logging_config import setup_logging
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -201,6 +202,9 @@ def _check_config_permissions():
 def run(argv: list[str]):
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    # Initialize structured logging
+    setup_logging()
 
     # Check config file permissions on startup
     _check_config_permissions()

--- a/printpulse/illustrations.py
+++ b/printpulse/illustrations.py
@@ -21,8 +21,12 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from typing import Optional
 
+import logging
+
 from printpulse import ui
 from printpulse.secure_fs import secure_makedirs
+
+logger = logging.getLogger("printpulse.illustrations")
 
 # ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -686,7 +690,8 @@ def _generate_dalle_image(
         return resp.content
 
     except Exception as e:
-        ui.error_panel(f"DALL-E image generation failed: {e}", theme)
+        logger.error("DALL-E image generation failed: %s", e)
+        ui.error_panel("Image generation failed — check logs for details.", theme)
         return None
 
 
@@ -767,7 +772,8 @@ def _qa_vision_call(
         return (min(max(score, 1), 10), feedback)
 
     except Exception as e:
-        return (5, f"QA evaluation failed: {e}")
+        logger.error("QA evaluation failed: %s", e)
+        return (5, "QA evaluation failed — check logs for details.")
 
 
 # ─── Path-to-Raster Preview Rendering ───────────────────────────────────────

--- a/printpulse/logging_config.py
+++ b/printpulse/logging_config.py
@@ -1,0 +1,85 @@
+"""Logging configuration for PrintPulse.
+
+Sets up structured logging with:
+- Rotating file handler (~/.printpulse/printpulse.log)
+- Console handler (for systemd journal capture on Pi)
+- Configurable log level via PRINTPULSE_LOG_LEVEL env var
+"""
+
+import logging
+import os
+import platform
+from logging.handlers import RotatingFileHandler
+
+from printpulse.secure_fs import secure_makedirs
+
+_LOG_DIR = os.path.join(os.path.expanduser("~"), ".printpulse")
+_LOG_FILE = os.path.join(_LOG_DIR, "printpulse.log")
+_MAX_BYTES = 1_000_000  # 1 MB per log file
+_BACKUP_COUNT = 3        # Keep 3 rotated files
+
+_configured = False
+
+
+def setup_logging(level: str | None = None) -> logging.Logger:
+    """Configure and return the root PrintPulse logger.
+
+    Args:
+        level: Log level string (DEBUG, INFO, WARNING, ERROR).
+               Falls back to PRINTPULSE_LOG_LEVEL env var, then INFO.
+    """
+    global _configured
+
+    logger = logging.getLogger("printpulse")
+
+    if _configured:
+        return logger
+
+    # Determine log level
+    if level is None:
+        level = os.environ.get("PRINTPULSE_LOG_LEVEL", "INFO")
+    numeric_level = getattr(logging, level.upper(), logging.INFO)
+    logger.setLevel(numeric_level)
+
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # File handler with rotation
+    try:
+        secure_makedirs(_LOG_DIR)
+        file_handler = RotatingFileHandler(
+            _LOG_FILE, maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(formatter)
+        file_handler.setLevel(numeric_level)
+        logger.addHandler(file_handler)
+
+        # Set file permissions on the log file
+        if platform.system() != "Windows":
+            try:
+                os.chmod(_LOG_FILE, 0o600)
+            except OSError:
+                pass
+    except OSError:
+        pass  # Can't write logs — non-fatal
+
+    # Stream handler (stderr → systemd journal on Pi)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    stream_handler.setLevel(logging.WARNING)  # Only warnings+ to console
+    logger.addHandler(stream_handler)
+
+    _configured = True
+    return logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a child logger for a specific module.
+
+    Usage: logger = get_logger(__name__)
+    """
+    setup_logging()
+    return logging.getLogger(f"printpulse.{name}")

--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import os
 import time
 from datetime import datetime
 
 from printpulse import ui
 from printpulse.secure_fs import secure_write_json
+
+logger = logging.getLogger("printpulse.watch")
 
 SEEN_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_seen.json")
 
@@ -75,7 +78,8 @@ def fetch_new_items_multi(feed_urls: list[str], max_items: int = 3) -> list[dict
             items = fetch_new_items(url, max_items)
             all_items.extend(items)
         except Exception as e:
-            ui.error_panel(f"Feed error ({url}): {e}", "green")
+            logger.error("Feed fetch failed for %s: %s", url, e)
+            ui.error_panel("Feed error: could not fetch feed.", "green")
     return all_items
 
 
@@ -118,8 +122,8 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                     seen["ids"].add(entry_id)
                     if title:
                         seen["titles"].add(title)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Error seeding seen items for %s: %s", feed_url, e)
         _save_seen(seen)
         ui.success_message(
             f"First run: top {skip} story(ies) per feed will print now. "
@@ -145,8 +149,9 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                 try:
                     items = fetch_new_items_multi(feed_urls, max_prints)
                 except Exception as e:
+                    logger.error("Feed poll failed: %s", e)
                     live.update(RText(
-                        f"  [{now}] Feed error: {e}",
+                        f"  [{now}] Feed error — check logs for details",
                         style=t["error"],
                     ))
                     # Wait then retry
@@ -197,7 +202,8 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                             plot_callback(title, feed_item=item)
                             mark_seen([item])
                         except Exception as e:
-                            ui.error_panel(f"Plot error: {e}", theme)
+                            logger.error("Plot/print error: %s", e)
+                            ui.error_panel("Plot error — check logs for details.", theme)
 
                     # Resume Live for the next idle countdown
                     live.start()

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,71 @@
+"""Tests for printpulse.logging_config module."""
+
+import logging
+import os
+import sys
+
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+# Reset the _configured flag before each import to allow re-setup
+import printpulse.logging_config as lc
+
+
+class TestSetupLogging:
+    def setup_method(self):
+        """Reset logging state between tests."""
+        lc._configured = False
+        logger = logging.getLogger("printpulse")
+        logger.handlers.clear()
+
+    def test_returns_logger(self):
+        logger = lc.setup_logging()
+        assert isinstance(logger, logging.Logger)
+        assert logger.name == "printpulse"
+
+    def test_sets_level_from_argument(self):
+        logger = lc.setup_logging(level="DEBUG")
+        assert logger.level == logging.DEBUG
+
+    def test_idempotent(self):
+        logger1 = lc.setup_logging()
+        handler_count = len(logger1.handlers)
+        lc.setup_logging()  # Should not add more handlers
+        assert len(logger1.handlers) == handler_count
+
+    def test_default_level_is_info(self):
+        # Clear env var if set
+        old = os.environ.pop("PRINTPULSE_LOG_LEVEL", None)
+        try:
+            logger = lc.setup_logging()
+            assert logger.level == logging.INFO
+        finally:
+            if old is not None:
+                os.environ["PRINTPULSE_LOG_LEVEL"] = old
+
+    def test_env_var_override(self):
+        os.environ["PRINTPULSE_LOG_LEVEL"] = "WARNING"
+        try:
+            logger = lc.setup_logging()
+            assert logger.level == logging.WARNING
+        finally:
+            del os.environ["PRINTPULSE_LOG_LEVEL"]
+
+
+class TestGetLogger:
+    def setup_method(self):
+        lc._configured = False
+        logging.getLogger("printpulse").handlers.clear()
+
+    def test_returns_child_logger(self):
+        logger = lc.get_logger("mymodule")
+        assert logger.name == "printpulse.mymodule"
+
+    def test_is_logging_logger(self):
+        logger = lc.get_logger("test")
+        assert isinstance(logger, logging.Logger)
+
+    def test_initializes_parent(self):
+        lc.get_logger("test")
+        assert lc._configured is True


### PR DESCRIPTION
## Summary
- **New `printpulse/logging_config.py`** — structured logging with rotating file handler
  - Logs to `~/.printpulse/printpulse.log` (1MB max, 3 backups)
  - Configurable via `PRINTPULSE_LOG_LEVEL` env var (default: INFO)
  - Stream handler for systemd journal capture on Pi (WARNING+ only)
- **Sanitized error messages** — no more raw `{e}` in user-facing output:
  - DALL-E errors, QA failures, feed errors, plot errors all show generic messages
  - Full error details logged internally for debugging
- **Replaced silent exception swallowing** in `server.py`:
  - `except Exception: pass` → specific types (`OSError`, `subprocess.TimeoutExpired`) with logging
  - Service control actions (start/stop/restart) now log success and failure
- **8 new tests** for logging configuration

Fixes #4

## Test plan
- [x] All 8 logging tests pass locally
- [x] Ruff lint passes
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)