### PR TITLE
Remove auto-pip-install of dependencies

### DIFF
--- a/printpulse/__init__.py
+++ b/printpulse/__init__.py
@@ -1,24 +1,25 @@
 __version__ = "0.1.0"
 
 
-def ensure_dependency(package: str, import_name: str | None = None):
-    """Import a package, auto-installing it via pip if missing.
+def require_dependency(package: str, import_name: str | None = None):
+    """Import a package, raising a clear error if not installed.
 
     Args:
         package: The pip package name (e.g. "feedparser").
         import_name: The Python import name if different from the pip name.
+
+    Returns:
+        The imported module.
+
+    Raises:
+        ImportError: With a message explaining how to install the package.
     """
     import importlib
     mod_name = import_name or package
     try:
         return importlib.import_module(mod_name)
     except ImportError:
-        import subprocess
-        import sys
-        print(f"  Installing missing dependency: {package}...")
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", package],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        return importlib.import_module(mod_name)
+        raise ImportError(
+            f"Required package '{package}' is not installed. "
+            f"Install it with: pip install {package}"
+        ) from None

--- a/printpulse/ascii_art.py
+++ b/printpulse/ascii_art.py
@@ -29,7 +29,7 @@ def _cache_path(url: str) -> str:
 
 def fetch_image(url: str) -> bytes | None:
     """Download an image, with disk caching."""
-    from printpulse import ensure_dependency
+    from printpulse import require_dependency
 
     _ensure_cache_dir()
     cached = _cache_path(url)
@@ -38,7 +38,7 @@ def fetch_image(url: str) -> bytes | None:
         with open(cached, "rb") as f:
             return f.read()
 
-    requests = ensure_dependency("requests")
+    requests = require_dependency("requests")
     try:
         resp = requests.get(url, timeout=10, headers={
             "User-Agent": "PrintPulse/0.1 (RSS reader)",
@@ -69,8 +69,8 @@ def image_to_ascii(
       - At least 4 distinct chars used
       - Recognizable shapes/silhouettes
     """
-    from printpulse import ensure_dependency
-    ensure_dependency("Pillow", "PIL")
+    from printpulse import require_dependency
+    require_dependency("Pillow", "PIL")
     from PIL import Image, ImageEnhance, ImageOps
 
     img = Image.open(io.BytesIO(image_data))

--- a/printpulse/illustrations.py
+++ b/printpulse/illustrations.py
@@ -299,8 +299,8 @@ def get_paths_height(paths: list[str]) -> float:
 
 def _preprocess_image_with_params(image_bytes: bytes, preset: TracingPreset) -> bytes:
     """Convert DALL-E image to high-contrast B&W using given preset params."""
-    from printpulse import ensure_dependency
-    ensure_dependency("Pillow", "PIL")
+    from printpulse import require_dependency
+    require_dependency("Pillow", "PIL")
     from PIL import Image, ImageFilter, ImageOps
 
     img = Image.open(io.BytesIO(image_bytes))
@@ -327,8 +327,8 @@ def _trace_image_to_svg_with_params(
     image_bytes: bytes, preset: TracingPreset
 ) -> Optional[str]:
     """Trace a preprocessed B&W image to SVG using vtracer with given params."""
-    from printpulse import ensure_dependency
-    vtracer = ensure_dependency("vtracer")
+    from printpulse import require_dependency
+    vtracer = require_dependency("vtracer")
 
     secure_makedirs(CACHE_DIR)
     tmp_in = None
@@ -492,8 +492,8 @@ def _get_illustration_label(
     letter_text: str, kind: str, api_key: str
 ) -> str:
     """Ask GPT-4o for a 1-2 word annotation label for an illustration."""
-    from printpulse import ensure_dependency
-    openai = ensure_dependency("openai")
+    from printpulse import require_dependency
+    openai = require_dependency("openai")
 
     snippet = letter_text[:400].strip()
     prompt = _LABEL_PROMPT.format(kind=kind, snippet=snippet)
@@ -665,9 +665,9 @@ def _generate_dalle_image(
     theme: str = "green",
 ) -> Optional[bytes]:
     """Generate an image via DALL-E 3 API. Returns PNG bytes or None."""
-    from printpulse import ensure_dependency
-    openai = ensure_dependency("openai")
-    requests = ensure_dependency("requests")
+    from printpulse import require_dependency
+    openai = require_dependency("openai")
+    requests = require_dependency("requests")
 
     try:
         client = openai.OpenAI(api_key=api_key)
@@ -738,8 +738,8 @@ def _qa_vision_call(
 
     Returns (score 1-10, feedback string).
     """
-    from printpulse import ensure_dependency
-    openai = ensure_dependency("openai")
+    from printpulse import require_dependency
+    openai = require_dependency("openai")
 
     try:
         b64 = base64.b64encode(image_bytes).decode("utf-8")
@@ -786,8 +786,8 @@ def _render_paths_to_image(
     Returns PNG bytes. Handles M/L/C/Q/H/V/Z commands with cubic bezier
     sampling for reasonable visual accuracy.
     """
-    from printpulse import ensure_dependency
-    ensure_dependency("Pillow", "PIL")
+    from printpulse import require_dependency
+    require_dependency("Pillow", "PIL")
     from PIL import Image, ImageDraw
 
     # ── Pass 1: collect all coordinates for bounding box ──

--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -37,8 +37,8 @@ def fetch_new_items(feed_url: str, max_items: int = 3) -> list[dict]:
 
     Returns list of dicts with 'id', 'title', 'summary', '_entry', '_source' keys.
     """
-    from printpulse import ensure_dependency
-    feedparser = ensure_dependency("feedparser")
+    from printpulse import require_dependency
+    feedparser = require_dependency("feedparser")
 
     seen = _load_seen()
     feed = feedparser.parse(feed_url)
@@ -109,8 +109,8 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
     # First run: seed seen file, but leave the top N unseen so we
     # immediately print the current top story on first poll
     if not os.path.isfile(SEEN_FILE):
-        from printpulse import ensure_dependency
-        feedparser = ensure_dependency("feedparser")
+        from printpulse import require_dependency
+        feedparser = require_dependency("feedparser")
         seen = {"ids": set(), "titles": set()}
         skip = max_prints if max_prints > 0 else 1
         for feed_url in feed_urls:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,5 +1,7 @@
 """Smoke tests: verify all modules import without errors."""
 
+import pytest
+
 
 def test_import_config():
     from printpulse import config  # noqa: F401
@@ -43,3 +45,17 @@ def test_import_journal():
 
 def test_import_app():
     from printpulse import app  # noqa: F401
+
+
+def test_require_dependency_installed():
+    """require_dependency returns the module for installed packages."""
+    from printpulse import require_dependency
+    json_mod = require_dependency("json")
+    assert hasattr(json_mod, "dumps")
+
+
+def test_require_dependency_missing():
+    """require_dependency raises ImportError for missing packages."""
+    from printpulse import require_dependency
+    with pytest.raises(ImportError, match="pip install"):
+        require_dependency("nonexistent_package_xyz_12345")


### PR DESCRIPTION
## Summary
- **Replaced `ensure_dependency()`** (which auto-ran `pip install`) with **`require_dependency()`** which raises a clear `ImportError` with install instructions
- Updated all callers: `ascii_art.py`, `illustrations.py`, `watch.py`
- Eliminates supply chain risk from typosquatted or compromised PyPI packages
- 2 new tests verifying the behavior

Fixes #5

## Test plan
- [x] Tests pass locally
- [x] Ruff lint passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)