### PR TITLE
Show version in web UI footer

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -39,6 +39,39 @@ from pi.appliance import load_config, save_config, verify_password
 
 app = Flask(__name__)
 
+
+# ─── Version Info ──────────────────────────────────────────────────────────
+
+def _get_version_info() -> str:
+    """Get version string from pyproject.toml + git short hash."""
+    version = "unknown"
+    try:
+        toml_path = os.path.join(_project_root, "pyproject.toml")
+        with open(toml_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip().startswith("version"):
+                    version = line.split("=")[1].strip().strip('"').strip("'")
+                    break
+    except Exception:
+        pass
+
+    # Append git short hash
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=_project_root,
+        )
+        if result.returncode == 0:
+            version += f"+{result.stdout.strip()}"
+    except Exception:
+        pass
+
+    return version
+
+
+_APP_VERSION = _get_version_info()
+
 # Load secret key from config (generated during setup)
 _cfg = load_config()
 app.secret_key = _cfg.get("secret_key") or secrets.token_hex(32)
@@ -346,6 +379,7 @@ def index():
         printer_ok=printer_ok,
         feeds_text="\n".join(config.get("feeds", [])),
         errors=[],
+        version=_APP_VERSION,
     )
 
 
@@ -370,6 +404,7 @@ def save():
             printer_ok=printer_ok,
             feeds_text=request.form.get("feeds", ""),
             errors=errors,
+            version=_APP_VERSION,
         )
 
     config = load_config()

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -310,7 +310,7 @@
     </div>
 
     <div class="footer">
-        PrintPulse Appliance &mdash; Raspberry Pi Zero
+        PrintPulse v{{ version }} &mdash; Raspberry Pi Zero
     </div>
 
     <!-- Live status polling -->


### PR DESCRIPTION
## Summary
- Reads version from pyproject.toml + git short hash (e.g. `0.1.0+bafb8a3`)
- Displayed in the web UI footer so you can verify the Pi is running the latest code

Fixes #18

## Test plan
- [ ] Footer shows version like `PrintPulse v0.1.0+bafb8a3 — Raspberry Pi Zero`
- [ ] Version updates after `git pull` and service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)