### PR TITLE
Remove ornaments from stationery configs

### DIFF
--- a/printpulse/stationery.py
+++ b/printpulse/stationery.py
@@ -51,7 +51,7 @@ class IllustrationConfig:
 class StationeryProfile:
     name: str = "victorian"
     header: HeaderConfig = field(default_factory=HeaderConfig)
-    corner_ornaments: str = "gears"       # "gears", "flourishes", "simple"
+    corner_ornaments: str = "none"        # "none", "gears", "flourishes", "simple"
     body_font: str = "scripts"
     body_font_size: float = 12.0
     illustrations: IllustrationConfig = field(default_factory=IllustrationConfig)

--- a/printpulse/stationery/default.json
+++ b/printpulse/stationery/default.json
@@ -8,7 +8,7 @@
     "font_size": 20.0,
     "frame_style": "ornamental"
   },
-  "corner_ornaments": "gears",
+  "corner_ornaments": "none",
   "body_font": "futural",
   "body_font_size": 12.0,
   "illustrations": {

--- a/printpulse/stationery/victorian.json
+++ b/printpulse/stationery/victorian.json
@@ -8,7 +8,7 @@
     "font_size": 20.0,
     "frame_style": "ornamental"
   },
-  "corner_ornaments": "gears",
+  "corner_ornaments": "none",
   "body_font": "futural",
   "body_font_size": 12.0,
   "illustrations": {


### PR DESCRIPTION
## Summary
- Set `corner_ornaments` to `"none"` in both stationery JSON files
- Updated dataclass default to match

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)