### PR TITLE
Show timezone in quiet hours

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -40,6 +40,21 @@ from pi.appliance import load_config, save_config, verify_password
 app = Flask(__name__)
 
 
+# ─── Timezone Info ─────────────────────────────────────────────────────────
+
+def _get_system_timezone() -> str:
+    """Get a human-readable system timezone string."""
+    try:
+        from datetime import datetime, timezone
+        local_tz = datetime.now().astimezone().tzinfo
+        offset = datetime.now().astimezone().strftime("%z")
+        # Format as e.g. "PDT (UTC-0700)"
+        tz_name = datetime.now().astimezone().strftime("%Z")
+        return f"{tz_name} (UTC{offset[:3]}:{offset[3:]})"
+    except Exception:
+        return "unknown"
+
+
 # ─── Version Info ──────────────────────────────────────────────────────────
 
 def _get_version_info() -> str:
@@ -380,6 +395,7 @@ def index():
         feeds_text="\n".join(config.get("feeds", [])),
         errors=[],
         version=_APP_VERSION,
+        timezone=_get_system_timezone(),
     )
 
 
@@ -405,6 +421,7 @@ def save():
             feeds_text=request.form.get("feeds", ""),
             errors=errors,
             version=_APP_VERSION,
+            timezone=_get_system_timezone(),
         )
 
     config = load_config()

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -285,7 +285,7 @@
                                value="{{ config.quiet_end }}">
                     </div>
                 </div>
-                <div class="help">Printer stays silent between these hours. Articles queue and print when quiet hours end.</div>
+                <div class="help">Printer stays silent between these hours. Articles queue and print when quiet hours end. Timezone: {{ timezone }}</div>
             </div>
         </div>
 

--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -122,7 +122,11 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
     from rich.text import Text as RText
 
     feed_list = "\n".join(f"  {url}" for url in feed_urls)
-    quiet_label = f"Quiet hours: {quiet_start}–{quiet_end}" if quiet_start and quiet_end else "Quiet hours: off"
+    if quiet_start and quiet_end:
+        tz_name = datetime.now().astimezone().strftime("%Z")
+        quiet_label = f"Quiet hours: {quiet_start}–{quiet_end} ({tz_name})"
+    else:
+        quiet_label = "Quiet hours: off"
     ui.retro_panel(
         "WATCH MODE",
         f"Feeds ({len(feed_urls)}):\n{feed_list}\n"


### PR DESCRIPTION
## Summary
- Displays system timezone (e.g. "PDT (UTC-07:00)") in quiet hours help text
- Shows timezone in watcher startup panel

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)