### PR TITLE
Add print history page to web UI

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -523,6 +523,22 @@ def update():
     return redirect(url_for("index"))
 
 
+@app.route("/history")
+@require_auth
+def history():
+    """Show print history page."""
+    from printpulse.watch import load_history
+    items = load_history()
+    items.reverse()  # newest first
+    config = load_config()
+    return render_template(
+        "history.html",
+        items=items,
+        config=config,
+        version=_APP_VERSION,
+    )
+
+
 @app.route("/status")
 @require_auth
 def status_api():

--- a/pi/webapp/templates/history.html
+++ b/pi/webapp/templates/history.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PrintPulse — Print History</title>
+    <style>
+        :root {
+            {% if config.theme == 'amber' %}
+            --primary: #ffaa00;
+            --mid: #aa7700;
+            --dim: #665500;
+            --border: #6b5800;
+            --label: #dd9900;
+            --help: #5a4400;
+            --glow: #ffaa00;
+            {% else %}
+            --primary: #33ff33;
+            --mid: #1a8a1a;
+            --dim: #1a4a1a;
+            --border: #1a4a1a;
+            --label: #1aaa1a;
+            --help: #0d5a0d;
+            --glow: #33ff33;
+            {% endif %}
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            background: #0a0a0a;
+            color: var(--primary);
+            font-family: 'Courier New', monospace;
+            padding: 20px;
+            min-height: 100vh;
+        }
+
+        h1 {
+            text-align: center;
+            font-size: 1.6em;
+            margin-bottom: 5px;
+            text-shadow: 0 0 10px var(--glow);
+        }
+
+        .subtitle {
+            text-align: center;
+            color: var(--mid);
+            margin-bottom: 25px;
+            font-size: 0.85em;
+        }
+
+        .nav {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+
+        .nav a {
+            color: var(--mid);
+            text-decoration: none;
+            font-size: 0.85em;
+        }
+
+        .nav a:hover {
+            color: var(--primary);
+        }
+
+        .panel {
+            border: 2px solid var(--border);
+            padding: 20px;
+            margin-bottom: 20px;
+            background: #0d0d0d;
+        }
+
+        .panel-title {
+            color: var(--primary);
+            font-size: 1.1em;
+            margin-bottom: 15px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .history-item {
+            padding: 8px 0;
+            border-bottom: 1px solid #111;
+        }
+
+        .history-item:last-child {
+            border-bottom: none;
+        }
+
+        .history-title {
+            color: var(--primary);
+            font-size: 0.9em;
+        }
+
+        .history-meta {
+            color: var(--help);
+            font-size: 0.75em;
+            margin-top: 2px;
+        }
+
+        .empty {
+            color: var(--mid);
+            font-style: italic;
+            font-size: 0.85em;
+        }
+
+        .footer {
+            text-align: center;
+            color: var(--border);
+            font-size: 0.75em;
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+    <h1>[ PRINTPULSE ]</h1>
+    <div class="subtitle">Print History</div>
+    <div class="nav"><a href="/">&laquo; Back to Configuration</a></div>
+
+    <div class="panel">
+        <div class="panel-title">// RECENTLY PRINTED ({{ items|length }} items)</div>
+        {% if items %}
+            {% for item in items %}
+            <div class="history-item">
+                <div class="history-title">&gt; {{ item.title }}</div>
+                <div class="history-meta">
+                    {% if item.source %}{{ item.source }} &mdash; {% endif %}{{ item.timestamp }}
+                </div>
+            </div>
+            {% endfor %}
+        {% else %}
+            <div class="empty">No items printed yet.</div>
+        {% endif %}
+    </div>
+
+    <div class="footer">
+        PrintPulse v{{ version }} &mdash; Raspberry Pi Zero
+    </div>
+</body>
+</html>

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -194,7 +194,10 @@
 <body>
     <div style="display:flex; justify-content:space-between; align-items:center;">
         <h1>[ PRINTPULSE ]</h1>
-        <a href="/logout" style="color:var(--border); text-decoration:none; font-size:0.8em;">[ LOGOUT ]</a>
+        <div>
+            <a href="/history" style="color:var(--mid); text-decoration:none; font-size:0.8em;">[ HISTORY ]</a>
+            <a href="/logout" style="color:var(--border); text-decoration:none; font-size:0.8em;">[ LOGOUT ]</a>
+        </div>
     </div>
     <div class="subtitle">Appliance Configuration</div>
 

--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -10,6 +10,8 @@ from printpulse.secure_fs import secure_write_json
 logger = logging.getLogger("printpulse.watch")
 
 SEEN_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_seen.json")
+HISTORY_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_history.json")
+_MAX_HISTORY = 200  # Keep last N items
 
 
 def _load_seen() -> dict:
@@ -81,6 +83,33 @@ def fetch_new_items_multi(feed_urls: list[str], max_items: int = 3) -> list[dict
             logger.error("Feed fetch failed for %s: %s", url, e)
             ui.error_panel("Feed error: could not fetch feed.", "green")
     return all_items
+
+
+def load_history() -> list[dict]:
+    """Load print history: list of {title, source, timestamp}."""
+    if os.path.isfile(HISTORY_FILE):
+        try:
+            with open(HISTORY_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def _append_history(items: list[dict]):
+    """Append printed items to history with timestamps."""
+    history = load_history()
+    now_str = datetime.now().strftime("%Y-%m-%d %I:%M:%S %p")
+    for item in items:
+        history.append({
+            "title": item["title"],
+            "source": item.get("_source", ""),
+            "timestamp": now_str,
+        })
+    # Trim to max
+    if len(history) > _MAX_HISTORY:
+        history = history[-_MAX_HISTORY:]
+    secure_write_json(HISTORY_FILE, history)
 
 
 def mark_seen(items: list[dict]):
@@ -242,6 +271,7 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                         try:
                             plot_callback(title, feed_item=item)
                             mark_seen([item])
+                            _append_history([item])
                         except Exception as e:
                             logger.error("Plot/print error: %s", e)
                             ui.error_panel("Plot error — check logs for details.", theme)


### PR DESCRIPTION
## Summary
- Logs printed items to ~/.printpulse_history.json with title, source, and timestamp
- New `/history` page shows items newest-first (last 200)
- [ HISTORY ] link in main page header
- Themed to match green/amber

Fixes #17

## Test plan
- [ ] Print some items, verify they appear on /history
- [ ] History shows newest first with timestamps
- [ ] Respects green/amber theme
- [ ] HISTORY link visible on main page

🤖 Generated with [Claude Code](https://claude.com/claude-code)