### PR TITLE
Add test print button to web UI

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -539,6 +539,33 @@ def history():
     )
 
 
+@app.route("/test_print", methods=["POST"])
+@require_auth
+def test_print():
+    """Send a test news story to the thermal printer."""
+    client_ip = request.remote_addr or "unknown"
+    if _check_rate_limit(f"test_print:{client_ip}"):
+        return jsonify({"ok": False, "message": "Rate limit exceeded. Try again shortly."}), 429
+
+    from datetime import datetime
+    from printpulse.thermal import print_news_item
+
+    timestamp = datetime.now().strftime("%Y-%m-%d %I:%M:%S %p")
+    ok = print_news_item(
+        title="PrintPulse Test Print",
+        summary=(
+            "This is a test print from the PrintPulse web UI. "
+            "If you can read this, your thermal printer is working correctly."
+        ),
+        source="PrintPulse Appliance",
+        timestamp=timestamp,
+    )
+    logger.info("Test print requested: %s", "success" if ok else "failed")
+    if ok:
+        return jsonify({"ok": True, "message": "Test print sent successfully."})
+    return jsonify({"ok": False, "message": "Print failed — check printer connection."})
+
+
 @app.route("/status")
 @require_auth
 def status_api():

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -314,6 +314,10 @@
                 <button type="submit" class="btn-start" style="flex:1;">[ UPDATE ]</button>
             </form>
         </div>
+        <div class="btn-row" style="margin-top: 10px;">
+            <button type="button" id="test-print-btn" onclick="doTestPrint()" style="flex:1;">[ TEST PRINT ]</button>
+        </div>
+        <div id="test-print-result" style="display:none; margin-top:8px; font-size:0.85em; padding:6px 0;"></div>
     </div>
 
     <div class="footer">
@@ -322,6 +326,34 @@
 
     <!-- Live status polling -->
     <script>
+        function doTestPrint() {
+            var btn = document.getElementById('test-print-btn');
+            var result = document.getElementById('test-print-result');
+            btn.disabled = true;
+            btn.textContent = '[ PRINTING... ]';
+            result.style.display = 'none';
+
+            var formData = new FormData();
+            formData.append('csrf_token', '{{ csrf_token() }}');
+
+            fetch('/test_print', { method: 'POST', body: formData })
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    result.style.display = 'block';
+                    result.style.color = data.ok ? 'var(--primary)' : '#ff3333';
+                    result.textContent = '> ' + data.message;
+                })
+                .catch(function() {
+                    result.style.display = 'block';
+                    result.style.color = '#ff3333';
+                    result.textContent = '> Request failed.';
+                })
+                .finally(function() {
+                    btn.disabled = false;
+                    btn.textContent = '[ TEST PRINT ]';
+                });
+        }
+
         setInterval(function() {
             fetch('/status')
                 .then(r => r.json())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,104 @@
+"""Tests for the Pi web UI Flask routes."""
+
+import sys
+import os
+from unittest.mock import patch
+
+# Ensure pi/ is importable
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _project_root not in sys.path:
+    sys.path.insert(0, _project_root)
+
+
+def _make_client():
+    """Create a Flask test client with auth bypassed and a valid session."""
+    from pi.webapp.server import app
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    client = app.test_client()
+
+    # Establish a session with a CSRF token and authentication
+    with client.session_transaction() as sess:
+        sess["authenticated"] = True
+        sess["csrf_token"] = "testtoken"
+
+    return client
+
+
+class TestTestPrintRoute:
+    def test_test_print_success(self):
+        client = _make_client()
+        with patch("printpulse.thermal.print_news_item", return_value=True) as mock_print:
+            resp = client.post(
+                "/test_print",
+                data={"csrf_token": "testtoken"},
+                content_type="application/x-www-form-urlencoded",
+            )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert "success" in data["message"].lower()
+        mock_print.assert_called_once()
+
+    def test_test_print_printer_failure(self):
+        client = _make_client()
+        with patch("printpulse.thermal.print_news_item", return_value=False):
+            resp = client.post(
+                "/test_print",
+                data={"csrf_token": "testtoken"},
+                content_type="application/x-www-form-urlencoded",
+            )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is False
+        assert "failed" in data["message"].lower() or "check" in data["message"].lower()
+
+    def test_test_print_sends_title_and_source(self):
+        client = _make_client()
+        with patch("printpulse.thermal.print_news_item", return_value=True) as mock_print:
+            client.post(
+                "/test_print",
+                data={"csrf_token": "testtoken"},
+                content_type="application/x-www-form-urlencoded",
+            )
+        call_kwargs = mock_print.call_args
+        # Verify a meaningful title and source are passed
+        assert call_kwargs is not None
+        args, kwargs = call_kwargs
+        title = kwargs.get("title") or (args[0] if args else "")
+        source = kwargs.get("source") or (args[2] if len(args) > 2 else "")
+        assert len(title) > 0
+        assert len(source) > 0
+
+    def test_test_print_requires_csrf(self):
+        from pi.webapp.server import app
+        app.config["TESTING"] = True
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess["authenticated"] = True
+            sess["csrf_token"] = "realtoken"
+
+        # Send wrong token — should be rejected with 403
+        resp = client.post(
+            "/test_print",
+            data={"csrf_token": "wrongtoken"},
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert resp.status_code == 403
+
+    def test_test_print_requires_auth(self):
+        from pi.webapp.server import app
+        app.config["TESTING"] = True
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess["csrf_token"] = "testtoken"
+            # No 'authenticated' key
+
+        with patch("pi.webapp.server._is_auth_configured", return_value=True):
+            resp = client.post(
+                "/test_print",
+                data={"csrf_token": "testtoken"},
+                content_type="application/x-www-form-urlencoded",
+            )
+        # Should redirect to login
+        assert resp.status_code in (302, 403)


### PR DESCRIPTION
## Summary
- Adds a `[ TEST PRINT ]` button to the Service Control panel in the web UI
- Clicking it sends a formatted test news story (title, source, timestamp) to the thermal printer via a new `/test_print` POST endpoint
- Result (success or failure) appears inline below the button without a page reload
- Endpoint is protected by auth + CSRF + rate limiting

## Test plan
- [ ] Add new `tests/test_server.py` with 5 tests covering success, printer failure, content validation, CSRF enforcement, and auth gating — all passing
- [ ] Manual: verify button appears in Service Control panel, sends to printer, shows inline feedback

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)