### PR TITLE
Add durable message queue for quiet hours

### DIFF
--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -12,6 +12,7 @@ logger = logging.getLogger("printpulse.watch")
 SEEN_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_seen.json")
 HISTORY_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_history.json")
 RETRY_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_retry.json")
+QUIET_QUEUE_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_quiet_queue.json")
 _MAX_HISTORY = 200  # Keep last N items
 _MAX_RETRIES = 3    # Max retry attempts per item
 
@@ -156,6 +157,38 @@ def _remove_from_retry(item_id: str):
     _save_retry_queue(queue)
 
 
+def _load_quiet_queue() -> list[dict]:
+    """Load quiet-hours queue: list of {id, title, summary, _source}."""
+    if os.path.isfile(QUIET_QUEUE_FILE):
+        try:
+            with open(QUIET_QUEUE_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def _save_quiet_queue(queue: list[dict]):
+    """Save quiet-hours queue to disk."""
+    secure_write_json(QUIET_QUEUE_FILE, queue)
+
+
+def _enqueue_quiet_items(items: list[dict]):
+    """Persist items to the quiet queue, skipping duplicates."""
+    queue = _load_quiet_queue()
+    existing_ids = {q.get("id") for q in queue}
+    for item in items:
+        if item.get("id") not in existing_ids:
+            queue.append({
+                "id": item.get("id", ""),
+                "title": item.get("title", ""),
+                "summary": item.get("summary", ""),
+                "_source": item.get("_source", ""),
+            })
+            existing_ids.add(item.get("id"))
+    _save_quiet_queue(queue)
+
+
 def mark_seen(items: list[dict]):
     """Mark items as seen so they won't be plotted again."""
     seen = _load_seen()
@@ -249,6 +282,38 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                     style=t["primary"],
                 ))
 
+                # ── QUIET QUEUE: flush items saved during quiet hours ──
+                quiet_queue = _load_quiet_queue()
+                if quiet_queue and not (use_quiet and _is_in_quiet_hours(quiet_start, quiet_end)):
+                    live.stop()
+                    ui.retro_panel(
+                        "QUIET QUEUE",
+                        f"Quiet hours ended — printing {len(quiet_queue)} saved item(s).",
+                        theme,
+                    )
+                    _save_quiet_queue([])  # Clear before printing so a crash doesn't re-print
+                    for i, q_item in enumerate(quiet_queue, 1):
+                        title = q_item["title"]
+                        source = q_item.get("_source", "")
+                        label = f"QUEUED {i}/{len(quiet_queue)}"
+                        if source:
+                            label += f" ({source})"
+                        ui.retro_panel(label, title, theme)
+                        fake_item = {
+                            "id": q_item["id"], "title": title,
+                            "summary": q_item.get("summary", ""),
+                            "_source": source,
+                        }
+                        try:
+                            plot_callback(title, feed_item=fake_item)
+                            _append_history([fake_item])
+                            _remove_from_retry(q_item["id"])
+                        except Exception as e:
+                            logger.error("Quiet queue print error for '%s': %s", title, e)
+                            ui.error_panel("Print error — check logs for details.", theme)
+                            _add_to_retry(fake_item)
+                    live.start()
+
                 # ── RETRY QUEUE: process failed items first ──
                 retry_queue = _load_retry_queue()
                 retryable = [r for r in retry_queue if r.get("attempts", 0) < _MAX_RETRIES]
@@ -326,13 +391,17 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
 
                 # Stop Live temporarily to print story content normally
                 if items:
-                    # Check quiet hours — skip printing but don't mark as seen
+                    # Check quiet hours — persist to queue and mark seen so they're not lost
                     if use_quiet and _is_in_quiet_hours(quiet_start, quiet_end):
+                        _enqueue_quiet_items(items)
+                        mark_seen(items)
+                        total_queued = len(_load_quiet_queue())
                         live.update(RText(
-                            f"  [{now}] {len(items)} new item(s) queued — quiet hours ({quiet_start}–{quiet_end})",
+                            f"  [{now}] {len(items)} item(s) saved to quiet queue "
+                            f"({total_queued} total) — quiet hours ({quiet_start}–{quiet_end})",
                             style=t["primary"],
                         ))
-                        logger.info("Quiet hours active (%s–%s): %d item(s) deferred",
+                        logger.info("Quiet hours active (%s–%s): %d item(s) saved to queue",
                                     quiet_start, quiet_end, len(items))
                         items = []  # Clear so we skip the print block below
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,9 +1,19 @@
-"""Tests for watch module — quiet hours logic."""
+"""Tests for watch module — quiet hours logic and quiet queue."""
 
+import json
+import os
 from datetime import time as dtime
 from unittest.mock import patch
 
-from printpulse.watch import _is_in_quiet_hours
+import pytest
+
+from printpulse.watch import (
+    QUIET_QUEUE_FILE,
+    _enqueue_quiet_items,
+    _is_in_quiet_hours,
+    _load_quiet_queue,
+    _save_quiet_queue,
+)
 
 
 class TestIsInQuietHours:
@@ -79,3 +89,63 @@ class TestIsInQuietHours:
     def test_midnight_exactly_out_of_range(self):
         with self._mock_time(0, 0):
             assert _is_in_quiet_hours("01:00", "23:00") is False
+
+
+class TestQuietQueue:
+    """Test persistent quiet-hours queue."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_queue_file(self, tmp_path, monkeypatch):
+        """Redirect QUIET_QUEUE_FILE to a temp path for each test."""
+        tmp_queue = str(tmp_path / "quiet_queue.json")
+        monkeypatch.setattr("printpulse.watch.QUIET_QUEUE_FILE", tmp_queue)
+        # Also patch secure_write_json to write normally (it already does, but keep it real)
+        yield
+        # Cleanup handled by tmp_path fixture
+
+    def test_empty_queue_on_missing_file(self):
+        assert _load_quiet_queue() == []
+
+    def test_save_and_load_roundtrip(self):
+        items = [{"id": "1", "title": "Story A", "summary": "", "_source": "Feed X"}]
+        _save_quiet_queue(items)
+        loaded = _load_quiet_queue()
+        assert len(loaded) == 1
+        assert loaded[0]["title"] == "Story A"
+
+    def test_enqueue_adds_new_items(self):
+        items = [
+            {"id": "a1", "title": "Alpha", "summary": "s1", "_source": "Src1"},
+            {"id": "a2", "title": "Beta", "summary": "s2", "_source": "Src2"},
+        ]
+        _enqueue_quiet_items(items)
+        queue = _load_quiet_queue()
+        assert len(queue) == 2
+        assert queue[0]["id"] == "a1"
+        assert queue[1]["id"] == "a2"
+
+    def test_enqueue_skips_duplicates(self):
+        item = {"id": "dup", "title": "Dupe Story", "summary": "", "_source": "X"}
+        _enqueue_quiet_items([item])
+        _enqueue_quiet_items([item])  # second call — same id
+        assert len(_load_quiet_queue()) == 1
+
+    def test_enqueue_preserves_existing_items(self):
+        first = {"id": "first", "title": "First", "summary": "", "_source": "X"}
+        second = {"id": "second", "title": "Second", "summary": "", "_source": "X"}
+        _enqueue_quiet_items([first])
+        _enqueue_quiet_items([second])
+        queue = _load_quiet_queue()
+        assert len(queue) == 2
+
+    def test_save_empty_clears_queue(self):
+        _save_quiet_queue([{"id": "x", "title": "T", "summary": "", "_source": "S"}])
+        _save_quiet_queue([])
+        assert _load_quiet_queue() == []
+
+    def test_load_tolerates_corrupt_file(self, monkeypatch, tmp_path):
+        bad_file = str(tmp_path / "bad.json")
+        with open(bad_file, "w") as f:
+            f.write("not valid json{{{")
+        monkeypatch.setattr("printpulse.watch.QUIET_QUEUE_FILE", bad_file)
+        assert _load_quiet_queue() == []


### PR DESCRIPTION
## Summary

- Items found during quiet hours are now persisted to `~/.printpulse_quiet_queue.json` and marked seen immediately — they can no longer be silently lost if they rotate out of the RSS feed before quiet hours end
- At the start of each poll loop, if quiet hours are no longer active, the queue is flushed and all saved items are printed in order
- UI status line updated: shows count saved and total queued, e.g. `2 item(s) saved to quiet queue (5 total) — quiet hours (22:00–08:00)`
- Queue is cleared atomically before printing (crash-safe: items go to the retry queue on failure, not back to the quiet queue)

## Test plan

- [x] `TestQuietQueue` — 7 new unit tests covering load/save/enqueue/dedup/clear/corruption
- [x] All 21 watch tests pass, full suite clean, ruff lint passes

Fixes #36