### PR TITLE
Add automatic update check on a schedule

### DIFF
--- a/pi/appliance.py
+++ b/pi/appliance.py
@@ -31,6 +31,8 @@ def default_config() -> dict:
         "auth_user": "",
         "auth_hash": "",
         "secret_key": "",
+        "auto_update_enabled": False,
+        "auto_update_interval": 24,  # hours between checks (1, 6, 12, or 24)
     }
 
 

--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -15,12 +15,14 @@ Security features:
 
 import functools
 import ipaddress
+import json
 import logging
 import os
 import re
 import secrets
 import subprocess
 import sys
+import threading
 import time
 from urllib.parse import urlparse
 
@@ -90,6 +92,136 @@ _APP_VERSION = _get_version_info()
 # Load secret key from config (generated during setup)
 _cfg = load_config()
 app.secret_key = _cfg.get("secret_key") or secrets.token_hex(32)
+
+
+# ─── Auto-Update ────────────────────────────────────────────────────────────
+
+_UPDATE_LOG_FILE = os.path.join(os.path.expanduser("~"), ".printpulse_update_log.json")
+_UPDATE_LOG_MAX = 50
+
+# In-memory record of the most recent auto-update attempt
+_auto_update_state: dict = {
+    "last_check": None,   # ISO timestamp of last check
+    "last_result": None,  # human-readable result string
+    "last_changed": False,  # whether git pull fetched new commits
+}
+
+
+def _load_update_log() -> list[dict]:
+    """Load auto-update log from disk."""
+    if os.path.isfile(_UPDATE_LOG_FILE):
+        try:
+            with open(_UPDATE_LOG_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def _append_update_log(result: str, changed: bool):
+    """Append one entry to the update log and trim to max size."""
+    from datetime import datetime
+    log = _load_update_log()
+    log.append({
+        "timestamp": datetime.now().strftime("%Y-%m-%d %I:%M:%S %p"),
+        "result": result,
+        "changed": changed,
+    })
+    if len(log) > _UPDATE_LOG_MAX:
+        log = log[-_UPDATE_LOG_MAX:]
+    try:
+        from printpulse.secure_fs import secure_write_json
+        secure_write_json(_UPDATE_LOG_FILE, log)
+    except Exception as exc:
+        logger.warning("Could not write update log: %s", exc)
+
+
+def _run_auto_update() -> tuple[str, bool]:
+    """Run git pull and, if new commits landed, restart services.
+
+    Returns (result_message, changed) where changed is True if
+    git pull fetched new commits.
+    """
+    global _APP_VERSION
+
+    # Git pull
+    try:
+        result = subprocess.run(
+            ["git", "-C", _project_root, "pull", "--ff-only"],
+            capture_output=True, text=True, timeout=30,
+        )
+        pull_output = (result.stdout.strip() or result.stderr.strip()
+                       or "no output")
+        logger.info("Auto-update git pull: %s", pull_output)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        msg = f"git pull failed: {type(exc).__name__}"
+        logger.error("Auto-update %s", msg)
+        return msg, False
+
+    changed = "already up to date" not in pull_output.lower()
+
+    if not changed:
+        return "Already up to date.", False
+
+    # New commits — restart services
+    msgs = [f"git pull: {pull_output}"]
+    try:
+        subprocess.run(["sudo", "systemctl", "restart", "printpulse"], timeout=10)
+        msgs.append("printpulse: restarted")
+        logger.info("Auto-update restarted printpulse")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        msgs.append(f"printpulse: restart failed ({type(exc).__name__})")
+        logger.error("Auto-update failed to restart printpulse: %s", exc)
+
+    # Refresh in-process version string before restarting the web service
+    _APP_VERSION = _get_version_info()
+
+    # Restart printpulse-web last (kills this process — use Popen so we don't block)
+    try:
+        subprocess.Popen(["sudo", "systemctl", "restart", "printpulse-web"])
+        msgs.append("printpulse-web: restarting")
+        logger.info("Auto-update triggered printpulse-web restart")
+    except OSError as exc:
+        msgs.append(f"printpulse-web: restart failed ({type(exc).__name__})")
+        logger.error("Auto-update failed to restart printpulse-web: %s", exc)
+
+    return " | ".join(msgs), True
+
+
+def _auto_update_worker():
+    """Daemon thread: check for code updates on the configured schedule."""
+    # Record startup time as the baseline so we don't update immediately
+    last_check_at = time.time()
+
+    while True:
+        time.sleep(60)  # Wake up every minute to re-read config
+        try:
+            cfg = load_config()
+            if not cfg.get("auto_update_enabled", False):
+                continue
+            interval_sec = int(cfg.get("auto_update_interval", 24)) * 3600
+            now = time.time()
+            if now - last_check_at < interval_sec:
+                continue
+
+            last_check_at = now
+            from datetime import datetime
+            check_ts = datetime.now().strftime("%Y-%m-%d %I:%M:%S %p")
+            logger.info("Auto-update: running scheduled check")
+
+            result_msg, changed = _run_auto_update()
+
+            _auto_update_state["last_check"] = check_ts
+            _auto_update_state["last_result"] = result_msg
+            _auto_update_state["last_changed"] = changed
+            _append_update_log(result_msg, changed)
+        except Exception as exc:
+            logger.error("Auto-update worker error: %s", exc)
+
+
+# Start the background auto-update thread
+_update_thread = threading.Thread(target=_auto_update_worker, daemon=True, name="auto-updater")
+_update_thread.start()
 
 
 # ─── Rate Limiting ──────────────────────────────────────────────────────────
@@ -330,6 +462,20 @@ def validate_save_input(form) -> tuple[dict | None, list[str]]:
             if hh > 23 or mm > 59:
                 errors.append(f"{label} is not a valid time.")
 
+    # --- Auto-update ---
+    auto_update_enabled = form.get("auto_update_enabled") == "1"
+    _valid_intervals = {1, 6, 12, 24}
+    try:
+        auto_update_interval = int(form.get("auto_update_interval", 24))
+    except (ValueError, TypeError):
+        errors.append("Auto-update interval must be a number.")
+        auto_update_interval = 24
+    if auto_update_interval not in _valid_intervals:
+        errors.append(
+            f"Auto-update interval must be one of: {', '.join(str(v) for v in sorted(_valid_intervals))} hours."
+        )
+        auto_update_interval = 24
+
     # --- Printer device ---
     printer_device = form.get("printer_device", "/dev/usb/lp0").strip()
     if len(printer_device) > 64:
@@ -354,6 +500,8 @@ def validate_save_input(form) -> tuple[dict | None, list[str]]:
         "quiet_enabled": quiet_enabled,
         "quiet_start": quiet_start,
         "quiet_end": quiet_end,
+        "auto_update_enabled": auto_update_enabled,
+        "auto_update_interval": auto_update_interval,
     }, []
 
 
@@ -433,6 +581,8 @@ def save():
     config["quiet_enabled"] = validated["quiet_enabled"]
     config["quiet_start"] = validated["quiet_start"]
     config["quiet_end"] = validated["quiet_end"]
+    config["auto_update_enabled"] = validated["auto_update_enabled"]
+    config["auto_update_interval"] = validated["auto_update_interval"]
     save_config(config)
 
     # Restart the watcher service to pick up new config
@@ -573,7 +723,23 @@ def status_api():
     return jsonify({
         "service": _service_status(),
         "printer": _printer_detected(),
+        "auto_update": _auto_update_state.copy(),
     })
+
+
+@app.route("/update_log")
+@require_auth
+def update_log():
+    """Show auto-update log page."""
+    items = _load_update_log()
+    items = list(reversed(items))  # newest first
+    config = load_config()
+    return render_template(
+        "update_log.html",
+        items=items,
+        config=config,
+        version=_APP_VERSION,
+    )
 
 
 if __name__ == "__main__":

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -196,6 +196,7 @@
         <h1>[ PRINTPULSE ]</h1>
         <div>
             <a href="/history" style="color:var(--mid); text-decoration:none; font-size:0.8em;">[ HISTORY ]</a>
+            <a href="/update_log" style="color:var(--mid); text-decoration:none; font-size:0.8em;">[ UPDATE LOG ]</a>
             <a href="/logout" style="color:var(--border); text-decoration:none; font-size:0.8em;">[ LOGOUT ]</a>
         </div>
     </div>
@@ -292,6 +293,31 @@
             </div>
         </div>
 
+        <div class="panel">
+            <div class="panel-title">// AUTO-UPDATE</div>
+            <div class="checkbox-row">
+                <input type="checkbox" name="auto_update_enabled" id="auto_update_enabled"
+                       value="1" {% if config.auto_update_enabled %}checked{% endif %}
+                       onchange="document.getElementById('auto-update-opts').style.opacity = this.checked ? '1' : '0.4'">
+                <label for="auto_update_enabled">Automatically pull updates from GitHub</label>
+            </div>
+            <div id="auto-update-opts" style="opacity: {% if config.auto_update_enabled %}1{% else %}0.4{% endif %}; margin-top: 8px;">
+                <label for="auto_update_interval">Check interval:</label>
+                <select name="auto_update_interval" id="auto_update_interval">
+                    <option value="1"  {% if config.auto_update_interval == 1  %}selected{% endif %}>Every hour</option>
+                    <option value="6"  {% if config.auto_update_interval == 6  %}selected{% endif %}>Every 6 hours</option>
+                    <option value="12" {% if config.auto_update_interval == 12 %}selected{% endif %}>Every 12 hours</option>
+                    <option value="24" {% if config.auto_update_interval == 24 %}selected{% endif %}>Daily (every 24 hours)</option>
+                </select>
+                <div class="help">Only restarts services if new commits are found. First check runs after one full interval.</div>
+                {% if config.auto_update_enabled %}
+                <div id="auto-update-status" style="margin-top: 6px; font-size: 0.8em; color: var(--mid);">
+                    Last check: <span id="au-last-check">loading...</span>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
         <div class="btn-row">
             <button type="submit" class="btn-save">[ SAVE & RESTART ]</button>
         </div>
@@ -371,6 +397,16 @@
 
                     prtText.textContent = data.printer ? 'connected' : 'not found';
                     prtDot.className = 'dot ' + (data.printer ? 'dot-green' : 'dot-red');
+
+                    var auEl = document.getElementById('au-last-check');
+                    if (auEl && data.auto_update) {
+                        var au = data.auto_update;
+                        if (au.last_check) {
+                            auEl.textContent = au.last_check + ' — ' + au.last_result;
+                        } else {
+                            auEl.textContent = 'not yet checked';
+                        }
+                    }
                 })
                 .catch(function() {});
         }, 5000);

--- a/pi/webapp/templates/update_log.html
+++ b/pi/webapp/templates/update_log.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PrintPulse — Update Log</title>
+    <style>
+        :root {
+            {% if config.theme == 'amber' %}
+            --primary: #ffaa00;
+            --mid: #aa7700;
+            --dim: #665500;
+            --border: #6b5800;
+            --help: #5a4400;
+            --glow: #ffaa00;
+            {% else %}
+            --primary: #33ff33;
+            --mid: #1a8a1a;
+            --dim: #1a4a1a;
+            --border: #1a4a1a;
+            --help: #0d5a0d;
+            --glow: #33ff33;
+            {% endif %}
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            background: #0a0a0a;
+            color: var(--primary);
+            font-family: 'Courier New', monospace;
+            padding: 20px;
+            min-height: 100vh;
+        }
+
+        h1 {
+            text-align: center;
+            font-size: 1.6em;
+            margin-bottom: 5px;
+            text-shadow: 0 0 10px var(--glow);
+        }
+
+        .subtitle {
+            text-align: center;
+            color: var(--mid);
+            margin-bottom: 25px;
+            font-size: 0.85em;
+        }
+
+        .panel {
+            border: 2px solid var(--border);
+            padding: 20px;
+            margin-bottom: 20px;
+            background: #0d0d0d;
+        }
+
+        .panel-title {
+            color: var(--primary);
+            font-size: 1.1em;
+            margin-bottom: 15px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.85em;
+        }
+
+        th {
+            text-align: left;
+            color: var(--mid);
+            padding: 6px 8px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        td {
+            padding: 6px 8px;
+            border-bottom: 1px solid var(--dim);
+            vertical-align: top;
+            word-break: break-word;
+        }
+
+        .changed-yes { color: var(--primary); }
+        .changed-no  { color: var(--mid); }
+
+        .empty {
+            color: var(--help);
+            font-style: italic;
+            padding: 20px 0;
+            text-align: center;
+        }
+
+        .footer {
+            text-align: center;
+            color: var(--border);
+            font-size: 0.75em;
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+    <div style="display:flex; justify-content:space-between; align-items:center;">
+        <h1>[ PRINTPULSE ]</h1>
+        <div>
+            <a href="/" style="color:var(--mid); text-decoration:none; font-size:0.8em;">[ HOME ]</a>
+            <a href="/logout" style="color:var(--border); text-decoration:none; font-size:0.8em;">[ LOGOUT ]</a>
+        </div>
+    </div>
+    <div class="subtitle">Auto-Update Log</div>
+
+    <div class="panel">
+        <div class="panel-title">// UPDATE HISTORY</div>
+        {% if items %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Timestamp</th>
+                    <th>Updated?</th>
+                    <th>Result</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in items %}
+                <tr>
+                    <td style="white-space:nowrap; color:var(--mid);">{{ item.timestamp }}</td>
+                    <td class="{% if item.changed %}changed-yes{% else %}changed-no{% endif %}">
+                        {% if item.changed %}YES{% else %}no{% endif %}
+                    </td>
+                    <td>{{ item.result }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <div class="empty">No auto-update checks recorded yet.</div>
+        {% endif %}
+    </div>
+
+    <div class="footer">
+        PrintPulse v{{ version }} &mdash; Raspberry Pi Zero
+    </div>
+</body>
+</html>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -102,3 +102,135 @@ class TestTestPrintRoute:
             )
         # Should redirect to login
         assert resp.status_code in (302, 403)
+
+
+class TestAutoUpdateValidation:
+    """Test validate_save_input() for auto-update fields."""
+
+    def _base_form(self, **overrides):
+        data = {
+            "feeds": "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+            "interval": "300",
+            "max_prints": "3",
+            "theme": "green",
+            "printer_device": "/dev/usb/lp0",
+            "quiet_enabled": "",
+            "quiet_start": "22:00",
+            "quiet_end": "08:00",
+            "auto_update_enabled": "",
+            "auto_update_interval": "24",
+        }
+        data.update(overrides)
+        return data
+
+    def test_auto_update_disabled_by_default(self):
+        from pi.webapp.server import validate_save_input
+        validated, errors = validate_save_input(self._base_form())
+        assert errors == []
+        assert validated["auto_update_enabled"] is False
+
+    def test_auto_update_enabled_flag(self):
+        from pi.webapp.server import validate_save_input
+        validated, errors = validate_save_input(self._base_form(auto_update_enabled="1"))
+        assert errors == []
+        assert validated["auto_update_enabled"] is True
+
+    def test_auto_update_interval_valid_values(self):
+        from pi.webapp.server import validate_save_input
+        for hours in [1, 6, 12, 24]:
+            validated, errors = validate_save_input(
+                self._base_form(auto_update_interval=str(hours))
+            )
+            assert errors == [], f"Unexpected errors for interval={hours}: {errors}"
+            assert validated["auto_update_interval"] == hours
+
+    def test_auto_update_interval_invalid_value(self):
+        from pi.webapp.server import validate_save_input
+        _, errors = validate_save_input(self._base_form(auto_update_interval="7"))
+        assert any("interval" in e.lower() for e in errors)
+
+    def test_auto_update_interval_non_numeric(self):
+        from pi.webapp.server import validate_save_input
+        _, errors = validate_save_input(self._base_form(auto_update_interval="daily"))
+        assert any("number" in e.lower() or "interval" in e.lower() for e in errors)
+
+    def test_auto_update_interval_returns_error_on_bad_input(self):
+        from pi.webapp.server import validate_save_input
+        validated, errors = validate_save_input(self._base_form(auto_update_interval="999"))
+        assert validated is None
+        assert any("interval" in e.lower() for e in errors)
+
+
+class TestAutoUpdateRoutes:
+    """Test /status includes auto_update and /update_log renders."""
+
+    def test_status_includes_auto_update_key(self):
+        client = _make_client()
+        resp = client.get("/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "auto_update" in data
+        assert "last_check" in data["auto_update"]
+        assert "last_result" in data["auto_update"]
+
+    def test_update_log_renders(self):
+        client = _make_client()
+        with patch("pi.webapp.server._load_update_log", return_value=[]):
+            resp = client.get("/update_log")
+        assert resp.status_code == 200
+        assert b"UPDATE" in resp.data
+
+    def test_update_log_shows_entries(self):
+        client = _make_client()
+        fake_log = [
+            {"timestamp": "2026-03-23 10:00:00 AM", "result": "Already up to date.", "changed": False},
+            {"timestamp": "2026-03-23 11:00:00 AM", "result": "git pull: 1 file changed", "changed": True},
+        ]
+        with patch("pi.webapp.server._load_update_log", return_value=fake_log):
+            resp = client.get("/update_log")
+        assert resp.status_code == 200
+        assert b"Already up to date" in resp.data
+        assert b"1 file changed" in resp.data
+
+
+class TestRunAutoUpdate:
+    """Test _run_auto_update logic for changed vs unchanged."""
+
+    def test_already_up_to_date(self):
+        from pi.webapp.server import _run_auto_update
+        mock_result = type("R", (), {"returncode": 0, "stdout": "Already up to date.\n", "stderr": ""})()
+        with patch("subprocess.run", return_value=mock_result):
+            msg, changed = _run_auto_update()
+        assert changed is False
+        assert "up to date" in msg.lower()
+
+    def test_new_commits_triggers_restart(self):
+        from pi.webapp.server import _run_auto_update
+        pull_result = type("R", (), {
+            "returncode": 0,
+            "stdout": "Updating abc..def\nFast-forward\n 1 file changed",
+            "stderr": "",
+        })()
+        restart_result = type("R", (), {"returncode": 0})()
+        call_results = [pull_result, restart_result]
+        popen_calls = []
+
+        def fake_run(cmd, **kwargs):
+            return call_results.pop(0)
+
+        def fake_popen(cmd):
+            popen_calls.append(cmd)
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch("subprocess.Popen", side_effect=fake_popen):
+            msg, changed = _run_auto_update()
+
+        assert changed is True
+        assert len(popen_calls) == 1  # printpulse-web restart via Popen
+
+    def test_git_pull_failure(self):
+        from pi.webapp.server import _run_auto_update
+        with patch("subprocess.run", side_effect=OSError("not found")):
+            msg, changed = _run_auto_update()
+        assert changed is False
+        assert "failed" in msg.lower()


### PR DESCRIPTION
## Summary

- A daemon background thread runs inside `printpulse-web`, waking every minute to check whether the configured update interval has elapsed
- Configurable interval: **Every hour / 6 h / 12 h / Daily** — set in the web UI alongside an enable/disable toggle
- **Smart restart**: `git pull --ff-only` output is parsed; services only restart if new commits actually landed ("Already up to date." is a no-op)
- **Crash-safe web restart**: `printpulse-web` is restarted via `subprocess.Popen` (fire-and-forget) so the thread doesn't block waiting for the process it's killing
- Results persisted to `~/.printpulse_update_log.json` (last 50 entries)
- New **`/update_log`** page shows full history (timestamp · updated? · result)
- `/status` JSON now includes `auto_update` state for the live status poller
- Last check time + result shown inline in the auto-update panel when enabled

## Test plan

- [x] `TestAutoUpdateValidation` — 6 tests covering enabled flag, valid/invalid intervals, non-numeric input
- [x] `TestAutoUpdateRoutes` — 3 tests: `/status` includes key, `/update_log` renders, log entries display
- [x] `TestRunAutoUpdate` — 3 tests: already-up-to-date, new commits trigger restart, git pull failure
- [x] All 38 tests pass, ruff lint clean

Fixes #32