### PR TITLE
Add auto-bump version on releases

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,81 @@
+name: Bump Version
+
+# Runs after every push to main (e.g. a PR merge).
+# Increments the patch version in printpulse/__init__.py and pyproject.toml,
+# commits the change, and creates a vX.Y.Z tag.
+#
+# Guard: if the triggering commit is already a version-bump commit the job is
+# skipped, preventing an infinite loop.  The bump commit also carries
+# "[skip ci]" so the main CI workflow is suppressed for that push.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  bump:
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # needed to push commits and tags
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Use GITHUB_TOKEN so the push triggers tag creation
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          python3 - <<'PYEOF'
+          import re, os
+
+          # ── Read current version from __init__.py ──────────────────────────
+          with open("printpulse/__init__.py", "r") as f:
+              init_src = f.read()
+
+          m = re.search(r'__version__\s*=\s*["\'](\d+\.\d+\.\d+)["\']', init_src)
+          if not m:
+              raise SystemExit("Could not find __version__ in printpulse/__init__.py")
+          old = m.group(1)
+          major, minor, patch = old.split(".")
+          new = f"{major}.{minor}.{int(patch) + 1}"
+          print(f"Bumping {old} -> {new}")
+
+          # ── Update printpulse/__init__.py ──────────────────────────────────
+          init_src = re.sub(
+              r'(__version__\s*=\s*["\'])' + re.escape(old) + r'(["\'])',
+              rf'\g<1>{new}\g<2>',
+              init_src,
+          )
+          with open("printpulse/__init__.py", "w") as f:
+              f.write(init_src)
+
+          # ── Update pyproject.toml ──────────────────────────────────────────
+          with open("pyproject.toml", "r") as f:
+              toml_src = f.read()
+          toml_src = re.sub(
+              r'^(version\s*=\s*["\'])' + re.escape(old) + r'(["\'])',
+              rf'\g<1>{new}\g<2>',
+              toml_src,
+              flags=re.MULTILINE,
+          )
+          with open("pyproject.toml", "w") as f:
+              f.write(toml_src)
+
+          # ── Export outputs ─────────────────────────────────────────────────
+          with open(os.environ["GITHUB_OUTPUT"], "a") as gof:
+              gof.write(f"new_version={new}\n")
+              gof.write(f"old_version={old}\n")
+          PYEOF
+
+      - name: Commit and tag
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add printpulse/__init__.py pyproject.toml
+          git commit -m "chore: bump version ${{ steps.bump.outputs.new_version }} [skip ci]"
+          git tag "v${{ steps.bump.outputs.new_version }}"
+          git push origin main --follow-tags

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,6 @@
 """Tests for version info in the web UI server."""
 
+import re
 import sys
 import os
 
@@ -35,3 +36,30 @@ class TestGetVersionInfo:
         assert "+" in version
         git_hash = version.split("+")[1]
         assert len(git_hash) >= 7  # short hash is typically 7+ chars
+
+
+class TestVersionSync:
+    """Ensure __init__.py and pyproject.toml stay in sync.
+
+    The auto-bump workflow updates both files atomically; this test
+    catches any manual desync between them.
+    """
+
+    def test_init_version_matches_pyproject(self):
+        from printpulse import __version__
+
+        toml_path = os.path.join(_project_root, "pyproject.toml")
+        toml_version = None
+        with open(toml_path, "r", encoding="utf-8") as f:
+            for line in f:
+                m = re.match(r'^\s*version\s*=\s*["\']([^"\']+)["\']', line)
+                if m:
+                    toml_version = m.group(1)
+                    break
+
+        assert toml_version is not None, "Could not find version in pyproject.toml"
+        assert __version__ == toml_version, (
+            f"printpulse/__init__.py has __version__={__version__!r} "
+            f"but pyproject.toml has version={toml_version!r} — "
+            f"run the bump-version workflow or update both files together"
+        )


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/bump-version.yml` runs on every push to `main` (i.e. every PR merge)
- Increments the **patch** version (`0.1.0 → 0.1.1`) in both `printpulse/__init__.py` and `pyproject.toml`
- Commits `chore: bump version X.Y.Z [skip ci]` and pushes a `vX.Y.Z` tag automatically
- **Infinite-loop guard**: job is skipped if the triggering commit message starts with `chore: bump version`; the `[skip ci]` tag also suppresses all workflows for the bump commit itself
- New `TestVersionSync` test asserts that `__init__.py` and `pyproject.toml` always carry the same version string — will catch any manual desync

## How it works end-to-end

1. PR is merged to `main` → push event fires
2. `bump-version` workflow runs, bumps `0.1.0 → 0.1.1`, commits + tags `v0.1.1`
3. That commit carries `[skip ci]` — no further workflows run
4. `git tag v0.1.1` is visible under Releases / Tags on GitHub

## Test plan

- [x] `TestVersionSync::test_init_version_matches_pyproject` — verifies both version strings match
- [x] All 83 tests pass, ruff lint clean

Fixes #33