### PR TITLE
Show quiet hours status in web UI

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -527,6 +527,35 @@ def _printer_detected() -> bool:
     return os.path.exists(device)
 
 
+def _quiet_hours_active() -> dict:
+    """Check if quiet hours are currently active.
+
+    Returns dict with 'enabled', 'active', 'start', 'end' keys.
+    """
+    from datetime import datetime, time as dtime
+
+    config = load_config()
+    enabled = config.get("quiet_enabled", False)
+    start_str = config.get("quiet_start", "22:00")
+    end_str = config.get("quiet_end", "08:00")
+
+    if not enabled:
+        return {"enabled": False, "active": False, "start": start_str, "end": end_str}
+
+    now = datetime.now().time()
+    start_h, start_m = int(start_str[:2]), int(start_str[3:5])
+    end_h, end_m = int(end_str[:2]), int(end_str[3:5])
+    start = dtime(start_h, start_m)
+    end = dtime(end_h, end_m)
+
+    if start <= end:
+        active = start <= now < end
+    else:
+        active = now >= start or now < end
+
+    return {"enabled": True, "active": active, "start": start_str, "end": end_str}
+
+
 # ─── Routes ──────────────────────────────────────────────────────────────────
 
 @app.route("/")
@@ -535,11 +564,13 @@ def index():
     config = load_config()
     status = _service_status()
     printer_ok = _printer_detected()
+    quiet_hours = _quiet_hours_active()
     return render_template(
         "index.html",
         config=config,
         status=status,
         printer_ok=printer_ok,
+        quiet_hours=quiet_hours,
         feeds_text="\n".join(config.get("feeds", [])),
         errors=[],
         version=_APP_VERSION,
@@ -724,6 +755,7 @@ def status_api():
         "service": _service_status(),
         "printer": _printer_detected(),
         "auto_update": _auto_update_state.copy(),
+        "quiet_hours": _quiet_hours_active(),
     })
 
 

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -216,6 +216,11 @@
                   id="prt-dot"></span>
             <span>Printer: <strong id="prt-text">{% if printer_ok %}connected{% else %}not found{% endif %}</strong></span>
         </div>
+        <div class="status-item" id="quiet-status" style="{% if not quiet_hours.enabled %}display:none;{% endif %}">
+            <span class="dot {% if quiet_hours.active %}dot-yellow{% else %}dot-green{% endif %}"
+                  id="quiet-dot"></span>
+            <span>Quiet: <strong id="quiet-text">{% if quiet_hours.active %}active ({{ quiet_hours.start }}&ndash;{{ quiet_hours.end }}){% else %}off{% endif %}</strong></span>
+        </div>
     </div>
 
     <!-- Validation Errors -->
@@ -405,6 +410,23 @@
                             auEl.textContent = au.last_check + ' — ' + au.last_result;
                         } else {
                             auEl.textContent = 'not yet checked';
+                        }
+                    }
+
+                    // Quiet hours status
+                    if (data.quiet_hours) {
+                        var qh = data.quiet_hours;
+                        var qStatus = document.getElementById('quiet-status');
+                        var qDot = document.getElementById('quiet-dot');
+                        var qText = document.getElementById('quiet-text');
+                        if (qStatus) {
+                            qStatus.style.display = qh.enabled ? '' : 'none';
+                            if (qh.enabled) {
+                                qDot.className = 'dot ' + (qh.active ? 'dot-yellow' : 'dot-green');
+                                qText.textContent = qh.active
+                                    ? 'active (' + qh.start + '\u2013' + qh.end + ')'
+                                    : 'off';
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
## Summary
- Add quiet hours indicator to the status bar (yellow dot when active, green when off)
- Shows time range when active: "active (22:00–08:00)"
- Hidden when quiet hours are disabled in config
- Live-updates via the `/status` JSON polling endpoint

Fixes #41

## Test plan
- [ ] Enable quiet hours in config, verify yellow dot appears in status bar with time range
- [ ] Disable quiet hours, verify indicator disappears
- [ ] Check live polling updates the status without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)