### PR TITLE
Limit history list to last 10 items

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -680,10 +680,13 @@ def history():
     from printpulse.watch import load_history
     items = load_history()
     items.reverse()  # newest first
+    total = len(items)
+    items = items[:10]  # cap to 10 most recent for mobile performance
     config = load_config()
     return render_template(
         "history.html",
         items=items,
+        total=total,
         config=config,
         version=_APP_VERSION,
     )

--- a/pi/webapp/templates/history.html
+++ b/pi/webapp/templates/history.html
@@ -119,7 +119,7 @@
     <div class="nav"><a href="/">&laquo; Back to Configuration</a></div>
 
     <div class="panel">
-        <div class="panel-title">// RECENTLY PRINTED ({{ items|length }} items)</div>
+        <div class="panel-title">// RECENTLY PRINTED (showing {{ items|length }} of {{ total }})</div>
         {% if items %}
             {% for item in items %}
             <div class="history-item">


### PR DESCRIPTION
## Summary
- Cap print history page to 10 most recent items for mobile performance
- Show "showing X of Y" in panel title so users know the full count

Fixes #43

## Test plan
- [ ] Print several items, verify only last 10 show on history page
- [ ] Verify panel title shows correct "showing X of Y" count

🤖 Generated with [Claude Code](https://claude.com/claude-code)