### PR TITLE
OOBE: WiFi provisioning via AP mode + captive portal

### DIFF
--- a/pi/README.md
+++ b/pi/README.md
@@ -15,17 +15,19 @@ Configure everything from your phone or laptop via a web page on your local netw
 | **USB thermal printer** | Rongta 58mm, or any ESC/POS compatible receipt printer. ~$20-30 on Amazon. |
 | **Micro USB OTG adapter** | A tiny adapter that converts the Pi's micro-USB port to a regular USB port so you can plug in the printer. ~$5. Search "micro USB OTG adapter" on Amazon. |
 | **USB-C power supply** (for Zero 2 W) or **Micro USB power supply** (for Zero W) | The official Raspberry Pi power supply works great. Any 5V/2.5A phone charger will also work. |
-| **A computer** | Your Windows PC, to set up the SD card and SSH in. You only need this for initial setup. |
+| **A computer or phone** | For initial SD card flashing and WiFi setup. |
 
 **You do NOT need**: a monitor, keyboard, mouse, or HDMI cable. We'll set everything up "headlessly" over Wi-Fi.
 
 ---
 
-## Step 1: Flash the SD Card
+## Getting Started (New OOBE Flow)
 
-This puts the operating system onto your SD card.
+PrintPulse has a built-in WiFi setup experience. On first boot, the Pi creates its own WiFi hotspot so you can configure it from your phone — no need to pre-configure WiFi credentials.
 
-1. **Download Raspberry Pi Imager** from [raspberrypi.com/software](https://www.raspberrypi.com/software/) and install it on your Windows PC.
+### Step 1: Flash the SD Card
+
+1. **Download Raspberry Pi Imager** from [raspberrypi.com/software](https://www.raspberrypi.com/software/) and install it.
 
 2. **Insert your SD card** into your PC (use an adapter if needed).
 
@@ -34,74 +36,28 @@ This puts the operating system onto your SD card.
      - Pick the "Lite" version — no desktop needed, saves memory
    - Click **"Choose Storage"** → select your SD card
 
-4. **Click the gear icon** (⚙) in the bottom-right corner. This is the important part:
+4. **Click the gear icon** (⚙) in the bottom-right corner:
    - **Enable SSH**: check "Use password authentication"
-   - **Set username and password**: username = `pi`, pick a password you'll remember
-   - **Configure wireless LAN**: enter your Wi-Fi network name (SSID) and password
+   - **Set username and password**: pick a username and password you'll remember
+   - **Skip "Configure wireless LAN"** — PrintPulse handles WiFi setup for you!
    - **Set locale**: your timezone and keyboard layout
    - Click **Save**
 
 5. Click **"Write"** and wait for it to finish (~5 minutes).
 
-6. **Put the SD card in the Pi** and plug in power. The Pi will boot up and connect to your Wi-Fi automatically. Give it 2-3 minutes on the first boot.
+### Step 2: Initial Setup (one-time, requires temporary WiFi)
 
----
+For the initial setup script, you need the Pi on your network temporarily. You can either:
 
-## Step 2: Find Your Pi on the Network
+**Option A — Use Raspberry Pi Imager's WiFi setting** for this first boot only, then use PrintPulse's WiFi management going forward. Or:
 
-You need to find the Pi's IP address so you can connect to it.
+**Option B — Use the SD card WiFi file** (see [SD Card WiFi Provisioning](#sd-card-wifi-provisioning-power-user-alternative) below).
 
-### Option A: Use your router
-Log into your router's admin page (usually `192.168.1.1` or `192.168.0.1`). Look for a device named `raspberrypi` in the connected devices list.
+Once the Pi is on your network:
 
-### Option B: Use a command
-Open **Command Prompt** on your Windows PC and try:
-
-```
-ping raspberrypi.local
-```
-
-If it responds, your Pi's address is shown. If not, try:
-
-```
-arp -a
-```
-
-Look for an IP that wasn't there before (usually something like `192.168.1.XXX`).
-
-### Option C: Use an app
-Download **Fing** on your phone (free). It scans your network and shows all devices.
-
----
-
-## Step 3: Connect to the Pi via SSH
-
-SSH lets you type commands on the Pi from your Windows PC.
-
-1. Open **Command Prompt** (or PowerShell) on your Windows PC.
-
-2. Type:
-   ```
-   ssh pi@YOUR_PI_IP
-   ```
-   Replace `YOUR_PI_IP` with the IP you found in Step 2 (e.g., `ssh pi@192.168.1.42`).
-
-3. It will ask "Are you sure you want to continue connecting?" — type `yes` and press Enter.
-
-4. Enter the password you set in Step 1.
-
-You should now see a prompt like:
-```
-pi@raspberrypi:~ $
-```
-
-You're in! Everything from here is typed into this SSH window.
-
----
-
-## Step 4: Run the Setup Script
-
-This one command installs everything:
+1. **Find the Pi's IP** — check your router's admin page, or try `ping raspberrypi.local`
+2. **SSH in**: `ssh YOUR_USERNAME@YOUR_PI_IP`
+3. **Run the setup script**:
 
 ```bash
 git clone https://github.com/jampick/PrintPulse.git
@@ -109,32 +65,37 @@ bash PrintPulse/pi/setup.sh
 ```
 
 This takes about 5-10 minutes on a Pi Zero (it's a slow processor — be patient). It will:
-- Install Python and required packages
+- Install Python, NetworkManager, and avahi (mDNS)
 - Set up the PrintPulse software
+- Configure WiFi provisioning service
+- Set hostname to `printpulse` (reachable at `printpulse.local`)
 - Configure auto-start on boot
 - Start the web config UI
 
-When it's done, you'll see a message like:
-
-```
-╔═════════════════════════════════════════════════════╗
-║              SETUP COMPLETE!                       ║
-║                                                     ║
-║  Web UI:  http://192.168.1.42:5000                  ║
-╚═════════════════════════════════════════════════════╝
-```
-
-**Reboot once** to activate printer permissions:
+**Reboot** to activate everything:
 
 ```bash
 sudo reboot
 ```
 
-Wait a minute, then SSH back in if needed.
+### Step 3: Connect to PrintPulse WiFi (on subsequent boots)
 
----
+After setup, whenever the Pi can't find a known WiFi network, it automatically creates a hotspot:
 
-## Step 5: Plug in the Printer
+1. **On your phone or laptop**, look for the WiFi network **`PrintPulse-Setup`**
+2. **Connect to it** — a setup page will appear automatically (captive portal)
+3. **Select your home WiFi** from the list and enter your password
+4. **The Pi joins your network** — the setup hotspot disappears
+
+Now connect back to your home WiFi and visit:
+
+```
+http://printpulse.local:5000
+```
+
+(If `.local` doesn't work, find the Pi's IP in your router's admin page.)
+
+### Step 4: Plug in the Printer
 
 1. Plug the **USB OTG adapter** into the Pi's data USB port (the one closest to the center, NOT the power port).
 2. Plug your **thermal printer's USB cable** into the OTG adapter.
@@ -148,32 +109,53 @@ ls /dev/usb/lp0
 
 If you see `/dev/usb/lp0`, the printer is connected.
 
----
-
-## Step 6: Configure from Your Phone
+### Step 5: Configure from Your Phone
 
 1. Open a web browser on your phone or laptop.
-2. Go to `http://YOUR_PI_IP:5000` (the URL from the setup output).
-3. You'll see the PrintPulse configuration page.
+2. Go to `http://printpulse.local:5000`
+3. Log in with the credentials you set during setup.
+4. Add your RSS feeds and click **[ SAVE & RESTART ]**.
 
-### Add RSS Feeds
+---
 
-Paste one feed URL per line. Here are some good ones:
+## SD Card WiFi Provisioning (Power User Alternative)
+
+If you prefer to pre-configure WiFi without using the hotspot, create a text file called `printpulse-wifi.txt` on the SD card's boot partition:
 
 ```
-https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml
-http://feeds.bbci.co.uk/news/world/rss.xml
-https://feeds.npr.org/1001/rss.xml
+SSID=YourNetworkName
+PASSWORD=YourWiFiPassword
 ```
 
-### Adjust Settings
+**How it works:**
+- On first boot, PrintPulse checks for this file before starting AP mode
+- If found, it configures WiFi using the credentials and **deletes the file** (for security)
+- The AP hotspot is skipped entirely
 
-- **Poll interval**: How often to check for new stories (300 = every 5 minutes)
-- **Max prints per cycle**: How many stories to print each time (3 is a good default)
+**File location:**
+- **Raspberry Pi OS Bookworm** (newer): place on the `bootfs` partition (shows as `/boot/firmware/` on the Pi)
+- **Raspberry Pi OS Bullseye** (older): place on the `boot` partition (shows as `/boot/` on the Pi)
 
-### Save & Go
+**Notes:**
+- The file is deleted after use — your password is not left on the SD card
+- Leave `PASSWORD=` empty for open (unsecured) networks
+- Lines starting with `#` are treated as comments
 
-Click **[ SAVE & RESTART ]**. The watcher will restart with your new settings and start printing new headlines as they appear.
+---
+
+## Resetting WiFi
+
+If you move the appliance to a new network, or need to reconfigure WiFi:
+
+### From the Web UI
+Click the **[ RESET WIFI ]** button on the main configuration page. The Pi will drop back into AP mode (`PrintPulse-Setup` hotspot) so you can pick a new network.
+
+### From SSH
+```bash
+sudo systemctl restart printpulse-wifi
+```
+
+This re-runs the provisioning check. If the current WiFi is unavailable, the Pi will start AP mode.
 
 ---
 
@@ -182,7 +164,7 @@ Click **[ SAVE & RESTART ]**. The watcher will restart with your new settings an
 Once set up, you never need to SSH in again. Just:
 
 1. **Leave it plugged in** — it starts automatically on boot
-2. **Change settings** from your phone at `http://YOUR_PI_IP:5000`
+2. **Change settings** from your phone at `http://printpulse.local:5000`
 3. **Tear off printed stories** from the thermal printer
 
 ### What happens when...
@@ -193,10 +175,38 @@ Once set up, you never need to SSH in again. Just:
 | Wi-Fi drops temporarily | Watcher retries automatically, resumes when connected |
 | Printer runs out of paper | Replace paper roll, stories queue and print when ready |
 | You want to stop printing | Hit [ STOP ] on the web UI |
+| You move to a new WiFi network | Pi can't connect → starts AP mode → reconfigure from phone |
 
 ---
 
 ## Troubleshooting
+
+### WiFi Setup Issues
+
+**AP hotspot (`PrintPulse-Setup`) doesn't appear:**
+```bash
+# SSH in via ethernet or temporary WiFi and check:
+sudo systemctl status printpulse-wifi
+sudo journalctl -u printpulse-wifi -f
+
+# Verify NetworkManager is running:
+sudo systemctl status NetworkManager
+
+# Manually trigger AP mode:
+sudo nmcli connection up printpulse-ap
+```
+
+**Can't reach `printpulse.local`:**
+```bash
+# Check avahi is running:
+sudo systemctl status avahi-daemon
+
+# If .local doesn't work, find the IP directly:
+hostname -I
+```
+
+**Connected to AP but no captive portal:**
+- Open a browser manually and go to `http://192.168.4.1:5000/wifi`
 
 ### Check if the watcher is running
 
@@ -222,7 +232,7 @@ ls -la /dev/usb/lp0
 lsusb
 
 # Make sure you're in the lp group
-groups pi
+groups $(whoami)
 ```
 
 ### Restart everything
@@ -252,14 +262,29 @@ sudo systemctl restart printpulse printpulse-web
 ## Architecture
 
 ```
+                                     First Boot / No WiFi
+                                    ┌─────────────────────────┐
+                                    │  printpulse-wifi.service │
+                                    │  (runs before web/watch) │
+                                    │                          │
+                                    │  1. WiFi connected? ─yes─▶ Done
+                                    │  2. SD card config? ─yes─▶ Connect + Done
+                                    │  3. Start AP mode        │
+                                    │     SSID: PrintPulse-Setup│
+                                    └──────────┬──────────────┘
+                                               │
+                                    User connects to hotspot
+                                    picks home WiFi in portal
+                                               │
+                                               ▼
 Your Phone/Laptop                    Raspberry Pi Zero
 ┌──────────────┐                    ┌─────────────────────┐
 │   Browser    │───── Wi-Fi ──────▶│  Flask Web UI       │
 │  (port 5000) │                    │  (printpulse-web)   │
-└──────────────┘                    │         │           │
-                                    │    writes config    │
-                                    │         ▼           │
-                                    │  ~/.printpulse_     │
+│              │                    │         │           │
+│  printpulse  │                    │    writes config    │
+│  .local:5000 │                    │         ▼           │
+└──────────────┘                    │  ~/.printpulse_     │
                                     │  appliance.json     │
                                     │         │           │
                                     │    restarts service  │
@@ -269,3 +294,11 @@ Your Phone/Laptop                    Raspberry Pi Zero
                                     │  polls RSS feeds    │
                                     └─────────────────────┘
 ```
+
+### Systemd Services
+
+| Service | Purpose |
+|---------|---------|
+| `printpulse-wifi` | Runs once at boot: checks WiFi, tries SD card config, falls back to AP mode |
+| `printpulse-web` | Flask web UI on port 5000 (also serves the WiFi captive portal) |
+| `printpulse` | RSS feed watcher + thermal printer |

--- a/pi/setup.sh
+++ b/pi/setup.sh
@@ -22,13 +22,19 @@ echo "  Home: $PP_HOME"
 echo ""
 
 # ── 1. System packages ──────────────────────────────────────────
-echo "[1/7] Installing system packages..."
+echo "[1/8] Installing system packages..."
 sudo apt update -qq
-sudo apt install -y -qq python3 python3-venv python3-pip git > /dev/null 2>&1
+sudo apt install -y -qq python3 python3-venv python3-pip git network-manager avahi-daemon > /dev/null 2>&1
+# Ensure NetworkManager manages wlan0 (needed for AP mode)
+sudo systemctl enable NetworkManager 2>/dev/null || true
+sudo systemctl start NetworkManager 2>/dev/null || true
+# Enable mDNS for .local hostname resolution
+sudo systemctl enable avahi-daemon 2>/dev/null || true
+sudo systemctl start avahi-daemon 2>/dev/null || true
 echo "  OK"
 
 # ── 2. Clone repo (or update if already cloned) ─────────────────
-echo "[2/7] Setting up PrintPulse..."
+echo "[2/8] Setting up PrintPulse..."
 cd "$PP_HOME"
 
 if [ -d "PrintPulse" ]; then
@@ -42,7 +48,7 @@ else
 fi
 
 # ── 3. Create virtual environment and install ────────────────────
-echo "[3/7] Creating Python environment..."
+echo "[3/8] Creating Python environment..."
 python3 -m venv "$PP_HOME/printpulse-venv"
 source "$PP_HOME/printpulse-venv/bin/activate"
 
@@ -56,24 +62,26 @@ pip install --quiet --no-deps -e "$PP_HOME/PrintPulse"
 echo "  OK"
 
 # ── 4. USB printer permissions ───────────────────────────────────
-echo "[4/7] Setting up printer permissions..."
+echo "[4/8] Setting up printer permissions..."
 sudo usermod -a -G lp "$PP_USER" 2>/dev/null || true
 echo "  Added user '$PP_USER' to 'lp' group for USB printer access"
 
 # ── 5. Sudoers for service control (Flask needs this) ────────────
-echo "[5/7] Configuring service permissions..."
+echo "[5/8] Configuring service permissions..."
 sudo tee /etc/sudoers.d/printpulse > /dev/null << SUDOERS
 $PP_USER ALL=(ALL) NOPASSWD: /bin/systemctl restart printpulse
 $PP_USER ALL=(ALL) NOPASSWD: /bin/systemctl stop printpulse
 $PP_USER ALL=(ALL) NOPASSWD: /bin/systemctl start printpulse
 $PP_USER ALL=(ALL) NOPASSWD: /bin/systemctl is-active printpulse
 $PP_USER ALL=(ALL) NOPASSWD: /bin/systemctl restart printpulse-web
+$PP_USER ALL=(ALL) NOPASSWD: /bin/systemctl restart printpulse-wifi
+$PP_USER ALL=(ALL) NOPASSWD: /usr/bin/nmcli
 SUDOERS
 sudo chmod 440 /etc/sudoers.d/printpulse
 echo "  OK"
 
 # ── 6. Install systemd services ─────────────────────────────────
-echo "[6/7] Installing systemd services..."
+echo "[6/8] Installing systemd services..."
 
 # Generate service files with correct user and paths
 sudo tee /etc/systemd/system/printpulse.service > /dev/null << SVCFILE
@@ -120,12 +128,42 @@ StandardError=journal
 WantedBy=multi-user.target
 WEBFILE
 
+sudo tee /etc/systemd/system/printpulse-wifi.service > /dev/null << WIFIFILE
+[Unit]
+Description=PrintPulse WiFi Provisioning
+Before=printpulse.service printpulse-web.service
+After=NetworkManager.service
+Wants=NetworkManager.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=$PP_HOME/printpulse-venv/bin/python -c "import sys; sys.path.insert(0, '$PP_HOME/PrintPulse'); from pi.wifi_provision import run_provisioning_check; run_provisioning_check()"
+Environment=HOME=$PP_HOME
+Environment=PYTHONPATH=$PP_HOME/PrintPulse
+RemainAfterExit=yes
+TimeoutStartSec=60
+
+[Install]
+WantedBy=multi-user.target
+WIFIFILE
+
 sudo systemctl daemon-reload
-sudo systemctl enable printpulse printpulse-web
+sudo systemctl enable printpulse printpulse-web printpulse-wifi
 echo "  Services enabled (will start on boot)"
 
-# ── 7. Create config and set up web UI credentials ──────────────
-echo "[7/7] Setting up configuration and credentials..."
+# ── 7. Set hostname for mDNS ───────────────────────────────────
+echo "[7/8] Setting up mDNS hostname..."
+# Set hostname to 'printpulse' so the device is reachable at printpulse.local
+if [ "$(hostname)" != "printpulse" ]; then
+    sudo hostnamectl set-hostname printpulse 2>/dev/null || true
+    echo "  Hostname set to 'printpulse' (reachable at printpulse.local)"
+else
+    echo "  Hostname already set"
+fi
+
+# ── 8. Create config and set up web UI credentials ──────────────
+echo "[8/8] Setting up configuration and credentials..."
 echo ""
 echo "  The web UI requires a username and password."
 echo "  You'll use these to log in from your phone/laptop."

--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -41,6 +41,10 @@ from pi.appliance import load_config, save_config, verify_password
 
 app = Flask(__name__)
 
+# Register WiFi provisioning routes
+from pi.webapp.wifi_routes import wifi_bp
+app.register_blueprint(wifi_bp)
+
 
 # ─── Timezone Info ─────────────────────────────────────────────────────────
 

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -355,8 +355,10 @@
         </div>
         <div class="btn-row" style="margin-top: 10px;">
             <button type="button" id="test-print-btn" onclick="doTestPrint()" style="flex:1;">[ TEST PRINT ]</button>
+            <button type="button" id="wifi-reset-btn" onclick="doWifiReset()" style="flex:1; border-color: #ffaa00; color: #ffaa00;">[ RESET WIFI ]</button>
         </div>
         <div id="test-print-result" style="display:none; margin-top:8px; font-size:0.85em; padding:6px 0;"></div>
+        <div id="wifi-reset-result" style="display:none; margin-top:8px; font-size:0.85em; padding:6px 0;"></div>
     </div>
 
     <div class="footer">
@@ -390,6 +392,37 @@
                 .finally(function() {
                     btn.disabled = false;
                     btn.textContent = '[ TEST PRINT ]';
+                });
+        }
+
+        function doWifiReset() {
+            if (!confirm('Reset WiFi? The Pi will switch to AP mode (PrintPulse-Setup hotspot). You will lose connection to this page.')) {
+                return;
+            }
+            var btn = document.getElementById('wifi-reset-btn');
+            var result = document.getElementById('wifi-reset-result');
+            btn.disabled = true;
+            btn.textContent = '[ RESETTING... ]';
+            result.style.display = 'none';
+
+            var formData = new FormData();
+            formData.append('csrf_token', '{{ csrf_token() }}');
+
+            fetch('/wifi/reset', { method: 'POST', body: formData })
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    result.style.display = 'block';
+                    result.style.color = data.ok ? '#ffaa00' : '#ff3333';
+                    result.textContent = '> ' + data.message;
+                })
+                .catch(function() {
+                    result.style.display = 'block';
+                    result.style.color = '#ff3333';
+                    result.textContent = '> Connection lost (expected if AP mode activated).';
+                })
+                .finally(function() {
+                    btn.disabled = false;
+                    btn.textContent = '[ RESET WIFI ]';
                 });
         }
 

--- a/pi/webapp/templates/wifi_setup.html
+++ b/pi/webapp/templates/wifi_setup.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PrintPulse WiFi Setup</title>
+    <style>
+        :root {
+            --primary: #33ff33;
+            --mid: #1a8a1a;
+            --dim: #1a4a1a;
+            --border: #1a4a1a;
+            --glow: #33ff33;
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            background: #0a0a0a;
+            color: var(--primary);
+            font-family: 'Courier New', monospace;
+            padding: 20px;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        h1 {
+            font-size: 1.6em;
+            margin-bottom: 5px;
+            text-shadow: 0 0 10px var(--glow);
+            text-align: center;
+        }
+
+        .subtitle {
+            color: var(--mid);
+            margin-bottom: 25px;
+            font-size: 0.85em;
+            text-align: center;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 480px;
+        }
+
+        .panel {
+            border: 2px solid var(--border);
+            padding: 20px;
+            margin-bottom: 20px;
+            background: #0d0d0d;
+        }
+
+        .panel-title {
+            color: var(--primary);
+            font-size: 1.1em;
+            margin-bottom: 15px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .network-list {
+            list-style: none;
+        }
+
+        .network-item {
+            display: flex;
+            align-items: center;
+            padding: 10px;
+            border: 1px solid var(--border);
+            margin-bottom: 6px;
+            cursor: pointer;
+            transition: border-color 0.2s;
+        }
+
+        .network-item:hover {
+            border-color: var(--primary);
+        }
+
+        .network-item.selected {
+            border-color: var(--primary);
+            background: #0f1f0f;
+        }
+
+        .network-name {
+            flex: 1;
+            font-size: 0.95em;
+        }
+
+        .signal-bars {
+            font-size: 0.75em;
+            color: var(--mid);
+            margin-right: 10px;
+        }
+
+        .lock-icon {
+            font-size: 0.8em;
+            color: var(--mid);
+        }
+
+        label {
+            display: block;
+            color: var(--mid);
+            margin-bottom: 4px;
+            font-size: 0.85em;
+        }
+
+        input[type="text"], input[type="password"] {
+            width: 100%;
+            background: #111;
+            color: var(--primary);
+            border: 1px solid var(--border);
+            padding: 10px;
+            font-family: 'Courier New', monospace;
+            font-size: 0.95em;
+            margin-bottom: 12px;
+        }
+
+        input:focus {
+            outline: none;
+            border-color: var(--primary);
+            box-shadow: 0 0 5px var(--border);
+        }
+
+        button {
+            width: 100%;
+            background: #111;
+            color: var(--primary);
+            border: 2px solid var(--primary);
+            padding: 12px 20px;
+            font-family: 'Courier New', monospace;
+            font-size: 1em;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background: var(--primary);
+            color: #0a0a0a;
+        }
+
+        button:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .btn-rescan {
+            border-color: var(--mid);
+            color: var(--mid);
+            font-size: 0.85em;
+            padding: 8px;
+            margin-bottom: 15px;
+        }
+
+        .btn-rescan:hover {
+            background: var(--mid);
+            color: #0a0a0a;
+        }
+
+        .error {
+            color: #ff3333;
+            border-color: #ff3333;
+            padding: 10px;
+            margin-bottom: 15px;
+            font-size: 0.85em;
+            border: 1px solid #ff3333;
+        }
+
+        .success {
+            color: var(--primary);
+            border-color: var(--primary);
+            padding: 10px;
+            margin-bottom: 15px;
+            font-size: 0.85em;
+            border: 1px solid var(--primary);
+        }
+
+        .help {
+            color: var(--dim);
+            font-size: 0.75em;
+            margin-top: 8px;
+        }
+
+        .spinner {
+            display: none;
+            text-align: center;
+            color: var(--mid);
+            padding: 20px;
+            font-size: 0.9em;
+        }
+
+        .footer {
+            text-align: center;
+            color: var(--border);
+            font-size: 0.75em;
+            margin-top: 30px;
+        }
+
+        @media (max-width: 480px) {
+            body { padding: 12px; }
+            h1 { font-size: 1.3em; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>[ PRINTPULSE ]</h1>
+        <div class="subtitle">WiFi Setup</div>
+
+        {% if error %}
+        <div class="error">&gt; {{ error }}</div>
+        {% endif %}
+
+        {% if success %}
+        <div class="success">&gt; {{ success }}</div>
+        {% else %}
+
+        <form action="/wifi/connect" method="post" id="wifi-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+            <div class="panel">
+                <div class="panel-title">// SELECT NETWORK</div>
+
+                <a href="/wifi" style="text-decoration:none;">
+                    <button type="button" class="btn-rescan">[ RESCAN ]</button>
+                </a>
+
+                {% if networks %}
+                <ul class="network-list">
+                    {% for net in networks %}
+                    <li class="network-item" onclick="selectNetwork(this, '{{ net.ssid|e }}')">
+                        <span class="network-name">{{ net.ssid }}</span>
+                        <span class="signal-bars">{{ net.signal }}%</span>
+                        {% if net.security != 'Open' %}
+                        <span class="lock-icon">[SECURED]</span>
+                        {% else %}
+                        <span class="lock-icon">[OPEN]</span>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% else %}
+                <div style="color: var(--mid); padding: 10px;">No networks found. Try rescanning.</div>
+                {% endif %}
+            </div>
+
+            <div class="panel">
+                <div class="panel-title">// CONNECT</div>
+
+                <label for="ssid">Network name:</label>
+                <input type="text" name="ssid" id="ssid" placeholder="Select above or type manually"
+                       value="{{ request.form.get('ssid', '') }}">
+
+                <label for="password">Password:</label>
+                <input type="password" name="password" id="password" placeholder="Leave empty for open networks">
+
+                <button type="submit" id="connect-btn">[ CONNECT ]</button>
+                <div class="help">The Pi will restart its network. This page will stop responding
+                    — connect to your home WiFi and visit printpulse.local:5000</div>
+            </div>
+        </form>
+
+        <div class="spinner" id="spinner">
+            Connecting... please wait.<br>
+            The Pi is joining your WiFi network.<br><br>
+            Connect your device back to your home WiFi,<br>
+            then visit <strong>http://printpulse.local:5000</strong>
+        </div>
+        {% endif %}
+
+        <div class="footer">PrintPulse WiFi Setup</div>
+    </div>
+
+    <script>
+        function selectNetwork(el, ssid) {
+            document.querySelectorAll('.network-item').forEach(function(item) {
+                item.classList.remove('selected');
+            });
+            el.classList.add('selected');
+            document.getElementById('ssid').value = ssid;
+        }
+
+        var form = document.getElementById('wifi-form');
+        if (form) {
+            form.addEventListener('submit', function() {
+                document.getElementById('connect-btn').disabled = true;
+                document.getElementById('connect-btn').textContent = '[ CONNECTING... ]';
+                document.getElementById('spinner').style.display = 'block';
+            });
+        }
+    </script>
+</body>
+</html>

--- a/pi/webapp/wifi_routes.py
+++ b/pi/webapp/wifi_routes.py
@@ -1,0 +1,98 @@
+"""WiFi provisioning routes for the PrintPulse captive portal.
+
+These routes are registered as a Flask Blueprint and handle:
+- GET /wifi         — Show available networks + connect form
+- POST /wifi/connect — Attempt to join a WiFi network
+- POST /wifi/reset  — Drop back to AP mode (from main web UI)
+- GET /wifi/state   — JSON endpoint for current WiFi state
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, render_template, request, redirect, jsonify
+
+logger = logging.getLogger("printpulse.wifi_routes")
+
+wifi_bp = Blueprint("wifi", __name__)
+
+
+def _get_provision_module():
+    """Lazy import to keep things testable."""
+    from pi.wifi_provision import (
+        scan_wifi_networks,
+        connect_to_wifi,
+        start_ap_mode,
+        get_current_state,
+        validate_wifi_input,
+    )
+    return {
+        "scan": scan_wifi_networks,
+        "connect": connect_to_wifi,
+        "start_ap": start_ap_mode,
+        "state": get_current_state,
+        "validate": validate_wifi_input,
+    }
+
+
+@wifi_bp.route("/wifi")
+def wifi_setup():
+    """Captive portal landing page — list networks."""
+    prov = _get_provision_module()
+    networks = prov["scan"]()
+    return render_template("wifi_setup.html", networks=networks, error=None, success=None)
+
+
+@wifi_bp.route("/wifi/connect", methods=["POST"])
+def wifi_connect():
+    """Handle WiFi credential submission from the captive portal."""
+    prov = _get_provision_module()
+
+    ssid = request.form.get("ssid", "").strip()
+    password = request.form.get("password", "")
+
+    errors = prov["validate"](ssid, password)
+    if errors:
+        networks = prov["scan"]()
+        return render_template(
+            "wifi_setup.html",
+            networks=networks,
+            error=" ".join(errors),
+            success=None,
+        )
+
+    success, message = prov["connect"](ssid, password)
+
+    if success:
+        return render_template(
+            "wifi_setup.html",
+            networks=[],
+            error=None,
+            success=f"Connected to {ssid}! Connect to your home WiFi and visit printpulse.local:5000",
+        )
+    else:
+        networks = prov["scan"]()
+        return render_template(
+            "wifi_setup.html",
+            networks=networks,
+            error=f"Failed to connect: {message}",
+            success=None,
+        )
+
+
+@wifi_bp.route("/wifi/reset", methods=["POST"])
+def wifi_reset():
+    """Drop back to AP mode (called from the main web UI)."""
+    prov = _get_provision_module()
+    ok = prov["start_ap"]()
+    if ok:
+        return jsonify({"ok": True, "message": "AP mode activated. Connect to PrintPulse-Setup WiFi."})
+    return jsonify({"ok": False, "message": "Failed to start AP mode."}), 500
+
+
+@wifi_bp.route("/wifi/state")
+def wifi_state():
+    """JSON endpoint returning current WiFi provisioning state."""
+    prov = _get_provision_module()
+    return jsonify({"state": prov["state"]()})

--- a/pi/wifi_provision.py
+++ b/pi/wifi_provision.py
@@ -1,0 +1,385 @@
+"""PrintPulse OOBE — WiFi provisioning via AP mode + captive portal.
+
+On first boot (or when no known network is available), the Pi creates
+a hotspot named 'PrintPulse-Setup'.  Users connect from a phone or laptop,
+pick their home WiFi in the captive portal, and the Pi joins automatically.
+
+This module also supports an SD-card fallback: drop a file called
+``printpulse-wifi.txt`` onto the boot partition with::
+
+    SSID=MyNetwork
+    PASSWORD=MySecret
+
+and the Pi will configure WiFi on first boot without needing AP mode.
+
+All system calls are routed through helper functions so they can be
+mocked in tests (no real hardware required in CI).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import time
+
+logger = logging.getLogger("printpulse.wifi")
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+AP_SSID = "PrintPulse-Setup"
+AP_CHANNEL = 7
+AP_IP = "192.168.4.1"
+AP_SUBNET = "192.168.4.0/24"
+AP_DHCP_START = "192.168.4.10"
+AP_DHCP_END = "192.168.4.50"
+
+# SD-card provisioning file — Bookworm moved /boot to /boot/firmware
+_BOOT_PATHS = ["/boot/firmware", "/boot"]
+WIFI_CONFIG_FILENAME = "printpulse-wifi.txt"
+
+# NetworkManager connection name used by AP mode
+NM_AP_CONNECTION = "printpulse-ap"
+NM_HOME_CONNECTION = "printpulse-home"
+
+
+# ── State Machine ────────────────────────────────────────────────────────────
+
+class WifiState:
+    """Simple enum for the provisioning state machine."""
+    UNKNOWN = "unknown"
+    CONNECTED = "connected"       # On home WiFi — normal operation
+    AP_MODE = "ap_mode"           # Broadcasting setup hotspot
+    PROVISIONING = "provisioning"  # Credentials received, attempting connect
+    FAILED = "failed"             # Connection attempt failed
+
+
+# ── System helpers (mockable) ────────────────────────────────────────────────
+
+def _run(cmd: list[str], timeout: int = 30, check: bool = False) -> subprocess.CompletedProcess:
+    """Run a subprocess and return the result."""
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=check)
+
+
+def _file_exists(path: str) -> bool:
+    return os.path.isfile(path)
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def _delete_file(path: str) -> None:
+    os.remove(path)
+
+
+# ── Network State Detection ─────────────────────────────────────────────────
+
+def check_wifi_connected() -> bool:
+    """Return True if the wlan0 interface has an IP on a non-AP network."""
+    try:
+        result = _run(["nmcli", "-t", "-f", "DEVICE,STATE", "device"])
+        if result.returncode != 0:
+            return False
+        for line in result.stdout.strip().splitlines():
+            parts = line.split(":")
+            if len(parts) >= 2 and parts[0] == "wlan0" and parts[1] == "connected":
+                # Make sure it's not our own AP connection
+                active = _run(["nmcli", "-t", "-f", "NAME,DEVICE", "connection", "show", "--active"])
+                for aline in active.stdout.strip().splitlines():
+                    aparts = aline.split(":")
+                    if len(aparts) >= 2 and aparts[1] == "wlan0" and aparts[0] != NM_AP_CONNECTION:
+                        return True
+        return False
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def get_current_state() -> str:
+    """Determine current WiFi provisioning state."""
+    try:
+        result = _run(["nmcli", "-t", "-f", "NAME,DEVICE,TYPE", "connection", "show", "--active"])
+        for line in result.stdout.strip().splitlines():
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[0] == NM_AP_CONNECTION:
+                return WifiState.AP_MODE
+        if check_wifi_connected():
+            return WifiState.CONNECTED
+        return WifiState.UNKNOWN
+    except (OSError, subprocess.TimeoutExpired):
+        return WifiState.UNKNOWN
+
+
+# ── Network Scanning ─────────────────────────────────────────────────────────
+
+def scan_wifi_networks() -> list[dict]:
+    """Scan for available WiFi networks.
+
+    Returns a list of dicts with keys: ssid, signal, security.
+    """
+    networks: list[dict] = []
+    try:
+        # Rescan
+        _run(["nmcli", "device", "wifi", "rescan"], timeout=10)
+        time.sleep(2)
+
+        result = _run(["nmcli", "-t", "-f", "SSID,SIGNAL,SECURITY", "device", "wifi", "list"])
+        if result.returncode != 0:
+            return networks
+
+        seen: set[str] = set()
+        for line in result.stdout.strip().splitlines():
+            parts = line.split(":")
+            if len(parts) < 3:
+                continue
+            ssid = parts[0].strip()
+            if not ssid or ssid in seen or ssid == AP_SSID:
+                continue
+            seen.add(ssid)
+            try:
+                signal = int(parts[1])
+            except ValueError:
+                signal = 0
+            security = parts[2].strip() if parts[2].strip() else "Open"
+            networks.append({"ssid": ssid, "signal": signal, "security": security})
+
+        # Sort by signal strength descending
+        networks.sort(key=lambda n: n["signal"], reverse=True)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("WiFi scan failed: %s", exc)
+
+    return networks
+
+
+# ── AP Mode Control ──────────────────────────────────────────────────────────
+
+def start_ap_mode() -> bool:
+    """Activate the PrintPulse-Setup WiFi hotspot via NetworkManager.
+
+    Returns True on success.
+    """
+    logger.info("Starting AP mode: SSID=%s", AP_SSID)
+    try:
+        # Remove any existing AP connection first
+        _run(["nmcli", "connection", "delete", NM_AP_CONNECTION])
+
+        # Create AP hotspot
+        result = _run([
+            "nmcli", "connection", "add",
+            "type", "wifi",
+            "ifname", "wlan0",
+            "con-name", NM_AP_CONNECTION,
+            "autoconnect", "no",
+            "ssid", AP_SSID,
+            "mode", "ap",
+            "ipv4.method", "shared",
+            "ipv4.addresses", f"{AP_IP}/24",
+            "wifi-sec.key-mgmt", "none",
+        ])
+        if result.returncode != 0:
+            logger.error("Failed to create AP connection: %s", result.stderr)
+            return False
+
+        # Bring it up
+        result = _run(["nmcli", "connection", "up", NM_AP_CONNECTION])
+        if result.returncode != 0:
+            logger.error("Failed to activate AP: %s", result.stderr)
+            return False
+
+        logger.info("AP mode active at %s", AP_IP)
+        return True
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("AP mode start failed: %s", exc)
+        return False
+
+
+def stop_ap_mode() -> bool:
+    """Deactivate and remove the AP hotspot."""
+    logger.info("Stopping AP mode")
+    try:
+        _run(["nmcli", "connection", "down", NM_AP_CONNECTION])
+        _run(["nmcli", "connection", "delete", NM_AP_CONNECTION])
+        return True
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("AP mode stop failed: %s", exc)
+        return False
+
+
+# ── WiFi Connection ──────────────────────────────────────────────────────────
+
+def connect_to_wifi(ssid: str, password: str) -> tuple[bool, str]:
+    """Connect to a WiFi network.
+
+    Returns (success, message).
+    """
+    if not ssid or not ssid.strip():
+        return False, "SSID cannot be empty"
+    if len(ssid) > 32:
+        return False, "SSID too long (max 32 characters)"
+    if password and len(password) > 63:
+        return False, "Password too long (max 63 characters)"
+
+    logger.info("Attempting to connect to WiFi: %s", ssid)
+
+    try:
+        # Stop AP mode first if active
+        stop_ap_mode()
+        time.sleep(1)
+
+        # Remove any previous home connection
+        _run(["nmcli", "connection", "delete", NM_HOME_CONNECTION])
+
+        # Connect
+        cmd = [
+            "nmcli", "device", "wifi", "connect", ssid,
+            "name", NM_HOME_CONNECTION,
+        ]
+        if password:
+            cmd.extend(["password", password])
+
+        result = _run(cmd, timeout=30)
+
+        if result.returncode == 0:
+            logger.info("Connected to %s", ssid)
+            return True, f"Connected to {ssid}"
+        else:
+            err = result.stderr.strip() or result.stdout.strip() or "Connection failed"
+            logger.warning("Failed to connect to %s: %s", ssid, err)
+            return False, err
+
+    except subprocess.TimeoutExpired:
+        return False, "Connection timed out"
+    except OSError as exc:
+        return False, f"System error: {exc}"
+
+
+# ── SD Card Provisioning ────────────────────────────────────────────────────
+
+def parse_wifi_config_file(content: str) -> tuple[str | None, str | None]:
+    """Parse a printpulse-wifi.txt file.
+
+    Expected format (one key=value per line)::
+
+        SSID=MyNetwork
+        PASSWORD=MySecret
+
+    Returns (ssid, password).  Password may be None for open networks.
+    """
+    ssid = None
+    password = None
+
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        match = re.match(r"^(SSID|PASSWORD)\s*=\s*(.+)$", line, re.IGNORECASE)
+        if match:
+            key = match.group(1).upper()
+            value = match.group(2).strip()
+            if key == "SSID":
+                ssid = value
+            elif key == "PASSWORD":
+                password = value
+
+    return ssid, password
+
+
+def find_wifi_config_file() -> str | None:
+    """Look for printpulse-wifi.txt on the boot partition.
+
+    Returns the full path if found, else None.
+    """
+    for boot_dir in _BOOT_PATHS:
+        path = os.path.join(boot_dir, WIFI_CONFIG_FILENAME)
+        if _file_exists(path):
+            return path
+    return None
+
+
+def process_sd_card_config() -> tuple[bool, str]:
+    """Check for and process SD-card WiFi config.
+
+    If found, configures WiFi and deletes the file.
+    Returns (success, message).
+    """
+    config_path = find_wifi_config_file()
+    if config_path is None:
+        return False, "No SD card WiFi config found"
+
+    logger.info("Found SD card WiFi config at %s", config_path)
+
+    try:
+        content = _read_file(config_path)
+    except OSError as exc:
+        return False, f"Cannot read config file: {exc}"
+
+    ssid, password = parse_wifi_config_file(content)
+    if not ssid:
+        logger.warning("SD card config has no SSID")
+        return False, "Config file has no SSID"
+
+    success, msg = connect_to_wifi(ssid, password or "")
+
+    # Delete the file regardless of success (contains credentials)
+    try:
+        _delete_file(config_path)
+        logger.info("Deleted SD card config file: %s", config_path)
+    except OSError as exc:
+        logger.warning("Could not delete config file: %s", exc)
+
+    return success, msg
+
+
+# ── Boot-Time Provisioning Orchestrator ──────────────────────────────────────
+
+def run_provisioning_check() -> str:
+    """Run the full provisioning check sequence at boot.
+
+    1. If already connected to WiFi → done
+    2. Try SD card config → if success, done
+    3. Start AP mode for captive portal
+
+    Returns the resulting WifiState.
+    """
+    # Already connected?
+    if check_wifi_connected():
+        logger.info("WiFi already connected — skipping provisioning")
+        return WifiState.CONNECTED
+
+    # Try SD card first
+    success, msg = process_sd_card_config()
+    if success:
+        logger.info("WiFi configured via SD card: %s", msg)
+        return WifiState.CONNECTED
+
+    # Fall through to AP mode
+    if start_ap_mode():
+        logger.info("AP mode started — waiting for user to configure WiFi")
+        return WifiState.AP_MODE
+    else:
+        logger.error("Failed to start AP mode")
+        return WifiState.FAILED
+
+
+# ── Input Validation ─────────────────────────────────────────────────────────
+
+def validate_wifi_input(ssid: str, password: str) -> list[str]:
+    """Validate WiFi SSID and password from the captive portal form.
+
+    Returns a list of error strings (empty = valid).
+    """
+    errors: list[str] = []
+
+    if not ssid or not ssid.strip():
+        errors.append("Network name (SSID) is required.")
+    elif len(ssid) > 32:
+        errors.append("Network name too long (max 32 characters).")
+
+    if password and len(password) > 63:
+        errors.append("Password too long (max 63 characters).")
+    # Note: empty password is valid for open networks
+
+    return errors

--- a/tests/test_wifi_provision.py
+++ b/tests/test_wifi_provision.py
@@ -1,0 +1,409 @@
+"""Tests for the OOBE WiFi provisioning module.
+
+All system calls are mocked — no real hardware or NetworkManager needed.
+"""
+
+import os
+from unittest import mock
+
+import pytest
+
+from pi.wifi_provision import (
+    AP_SSID,
+    NM_AP_CONNECTION,
+    NM_HOME_CONNECTION,
+    WifiState,
+    check_wifi_connected,
+    connect_to_wifi,
+    find_wifi_config_file,
+    get_current_state,
+    parse_wifi_config_file,
+    process_sd_card_config,
+    run_provisioning_check,
+    scan_wifi_networks,
+    start_ap_mode,
+    stop_ap_mode,
+    validate_wifi_input,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _mock_run(stdout="", stderr="", returncode=0):
+    """Create a mock CompletedProcess."""
+    result = mock.MagicMock()
+    result.stdout = stdout
+    result.stderr = stderr
+    result.returncode = returncode
+    return result
+
+
+# ── parse_wifi_config_file ───────────────────────────────────────────────────
+
+class TestParseWifiConfigFile:
+    def test_basic(self):
+        ssid, pw = parse_wifi_config_file("SSID=MyNetwork\nPASSWORD=MySecret")
+        assert ssid == "MyNetwork"
+        assert pw == "MySecret"
+
+    def test_case_insensitive(self):
+        ssid, pw = parse_wifi_config_file("ssid=Test\npassword=pass123")
+        assert ssid == "Test"
+        assert pw == "pass123"
+
+    def test_with_spaces(self):
+        ssid, pw = parse_wifi_config_file("SSID = My Network\nPASSWORD = my pass")
+        assert ssid == "My Network"
+        assert pw == "my pass"
+
+    def test_comments_ignored(self):
+        content = "# WiFi config\nSSID=Net\n# password below\nPASSWORD=pass"
+        ssid, pw = parse_wifi_config_file(content)
+        assert ssid == "Net"
+        assert pw == "pass"
+
+    def test_empty_file(self):
+        ssid, pw = parse_wifi_config_file("")
+        assert ssid is None
+        assert pw is None
+
+    def test_ssid_only_open_network(self):
+        ssid, pw = parse_wifi_config_file("SSID=OpenNet")
+        assert ssid == "OpenNet"
+        assert pw is None
+
+    def test_blank_lines(self):
+        content = "\n\nSSID=Net\n\nPASSWORD=pass\n\n"
+        ssid, pw = parse_wifi_config_file(content)
+        assert ssid == "Net"
+        assert pw == "pass"
+
+    def test_malformed_lines_ignored(self):
+        content = "not a real line\nSSID=Good\ngarbage\nPASSWORD=yes"
+        ssid, pw = parse_wifi_config_file(content)
+        assert ssid == "Good"
+        assert pw == "yes"
+
+
+# ── validate_wifi_input ──────────────────────────────────────────────────────
+
+class TestValidateWifiInput:
+    def test_valid(self):
+        assert validate_wifi_input("MyNetwork", "password123") == []
+
+    def test_empty_ssid(self):
+        errors = validate_wifi_input("", "pass")
+        assert len(errors) == 1
+        assert "required" in errors[0].lower()
+
+    def test_ssid_too_long(self):
+        errors = validate_wifi_input("A" * 33, "pass")
+        assert len(errors) == 1
+        assert "32" in errors[0]
+
+    def test_password_too_long(self):
+        errors = validate_wifi_input("Net", "A" * 64)
+        assert len(errors) == 1
+        assert "63" in errors[0]
+
+    def test_open_network_no_password(self):
+        assert validate_wifi_input("OpenNet", "") == []
+
+    def test_whitespace_only_ssid(self):
+        errors = validate_wifi_input("   ", "pass")
+        assert len(errors) == 1
+
+
+# ── check_wifi_connected ─────────────────────────────────────────────────────
+
+class TestCheckWifiConnected:
+    @mock.patch("pi.wifi_provision._run")
+    def test_connected(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(stdout="wlan0:connected\n"),
+            _mock_run(stdout="my-home-wifi:wlan0\n"),
+        ]
+        assert check_wifi_connected() is True
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_not_connected(self, mock_run):
+        mock_run.return_value = _mock_run(stdout="wlan0:disconnected\n")
+        assert check_wifi_connected() is False
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_connected_to_ap_only(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(stdout="wlan0:connected\n"),
+            _mock_run(stdout=f"{NM_AP_CONNECTION}:wlan0\n"),
+        ]
+        assert check_wifi_connected() is False
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_nmcli_fails(self, mock_run):
+        mock_run.return_value = _mock_run(returncode=1)
+        assert check_wifi_connected() is False
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_os_error(self, mock_run):
+        mock_run.side_effect = OSError("nmcli not found")
+        assert check_wifi_connected() is False
+
+
+# ── get_current_state ────────────────────────────────────────────────────────
+
+class TestGetCurrentState:
+    @mock.patch("pi.wifi_provision.check_wifi_connected")
+    @mock.patch("pi.wifi_provision._run")
+    def test_ap_mode(self, mock_run, mock_connected):
+        mock_run.return_value = _mock_run(stdout=f"{NM_AP_CONNECTION}:wlan0:wifi\n")
+        assert get_current_state() == WifiState.AP_MODE
+
+    @mock.patch("pi.wifi_provision.check_wifi_connected")
+    @mock.patch("pi.wifi_provision._run")
+    def test_connected(self, mock_run, mock_connected):
+        mock_run.return_value = _mock_run(stdout="my-wifi:wlan0:wifi\n")
+        mock_connected.return_value = True
+        assert get_current_state() == WifiState.CONNECTED
+
+    @mock.patch("pi.wifi_provision.check_wifi_connected")
+    @mock.patch("pi.wifi_provision._run")
+    def test_unknown(self, mock_run, mock_connected):
+        mock_run.return_value = _mock_run(stdout="")
+        mock_connected.return_value = False
+        assert get_current_state() == WifiState.UNKNOWN
+
+
+# ── scan_wifi_networks ───────────────────────────────────────────────────────
+
+class TestScanWifiNetworks:
+    @mock.patch("pi.wifi_provision._run")
+    def test_scan_returns_sorted(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(),  # rescan
+            _mock_run(stdout="WeakNet:30:WPA2\nStrongNet:90:WPA2\nMidNet:60:Open\n"),
+        ]
+        networks = scan_wifi_networks()
+        assert len(networks) == 3
+        assert networks[0]["ssid"] == "StrongNet"
+        assert networks[0]["signal"] == 90
+        assert networks[2]["ssid"] == "WeakNet"
+        assert networks[1]["security"] == "Open"
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_deduplicates(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(),
+            _mock_run(stdout="Net:80:WPA2\nNet:70:WPA2\n"),
+        ]
+        networks = scan_wifi_networks()
+        assert len(networks) == 1
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_excludes_own_ap(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(),
+            _mock_run(stdout=f"{AP_SSID}:100:Open\nReal:80:WPA2\n"),
+        ]
+        networks = scan_wifi_networks()
+        assert len(networks) == 1
+        assert networks[0]["ssid"] == "Real"
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_empty_scan(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(),
+            _mock_run(stdout=""),
+        ]
+        assert scan_wifi_networks() == []
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_scan_failure(self, mock_run):
+        mock_run.side_effect = OSError("no nmcli")
+        assert scan_wifi_networks() == []
+
+
+# ── start_ap_mode / stop_ap_mode ─────────────────────────────────────────────
+
+class TestAPMode:
+    @mock.patch("pi.wifi_provision._run")
+    def test_start_success(self, mock_run):
+        mock_run.return_value = _mock_run()
+        assert start_ap_mode() is True
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_start_create_fails(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(),  # delete old
+            _mock_run(returncode=1, stderr="failed"),  # create fails
+        ]
+        assert start_ap_mode() is False
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_start_activate_fails(self, mock_run):
+        mock_run.side_effect = [
+            _mock_run(),  # delete old
+            _mock_run(),  # create ok
+            _mock_run(returncode=1, stderr="activate failed"),  # up fails
+        ]
+        assert start_ap_mode() is False
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_stop_success(self, mock_run):
+        mock_run.return_value = _mock_run()
+        assert stop_ap_mode() is True
+
+    @mock.patch("pi.wifi_provision._run")
+    def test_stop_os_error(self, mock_run):
+        mock_run.side_effect = OSError("fail")
+        assert stop_ap_mode() is False
+
+
+# ── connect_to_wifi ──────────────────────────────────────────────────────────
+
+class TestConnectToWifi:
+    @mock.patch("pi.wifi_provision._run")
+    @mock.patch("pi.wifi_provision.stop_ap_mode")
+    def test_success(self, mock_stop_ap, mock_run):
+        mock_stop_ap.return_value = True
+        mock_run.return_value = _mock_run()
+        ok, msg = connect_to_wifi("MyNet", "pass123")
+        assert ok is True
+        assert "MyNet" in msg
+
+    @mock.patch("pi.wifi_provision._run")
+    @mock.patch("pi.wifi_provision.stop_ap_mode")
+    def test_failure(self, mock_stop_ap, mock_run):
+        mock_stop_ap.return_value = True
+        mock_run.side_effect = [
+            _mock_run(),  # delete old connection
+            _mock_run(returncode=1, stderr="Wrong password"),  # connect fails
+        ]
+        ok, msg = connect_to_wifi("MyNet", "wrong")
+        assert ok is False
+        assert "Wrong password" in msg
+
+    def test_empty_ssid(self):
+        ok, msg = connect_to_wifi("", "pass")
+        assert ok is False
+        assert "empty" in msg.lower()
+
+    def test_ssid_too_long(self):
+        ok, msg = connect_to_wifi("A" * 33, "pass")
+        assert ok is False
+        assert "long" in msg.lower()
+
+    @mock.patch("pi.wifi_provision._run")
+    @mock.patch("pi.wifi_provision.stop_ap_mode")
+    def test_timeout(self, mock_stop_ap, mock_run):
+        mock_stop_ap.return_value = True
+        import subprocess
+        mock_run.side_effect = [
+            _mock_run(),  # delete
+            subprocess.TimeoutExpired(cmd="nmcli", timeout=30),
+        ]
+        ok, msg = connect_to_wifi("Net", "pass")
+        assert ok is False
+        assert "timed out" in msg.lower()
+
+
+# ── SD Card Provisioning ────────────────────────────────────────────────────
+
+class TestSDCardProvisioning:
+    @mock.patch("pi.wifi_provision._file_exists")
+    def test_find_bookworm_path(self, mock_exists):
+        bookworm = os.path.join("/boot/firmware", "printpulse-wifi.txt")
+        mock_exists.side_effect = lambda p: p == bookworm
+        assert find_wifi_config_file() == bookworm
+
+    @mock.patch("pi.wifi_provision._file_exists")
+    def test_find_bullseye_path(self, mock_exists):
+        bookworm = os.path.join("/boot/firmware", "printpulse-wifi.txt")
+        bullseye = os.path.join("/boot", "printpulse-wifi.txt")
+        # Bookworm path not found, Bullseye path found
+        mock_exists.side_effect = lambda p: p == bullseye
+        assert find_wifi_config_file() == bullseye
+
+    @mock.patch("pi.wifi_provision._file_exists")
+    def test_find_not_found(self, mock_exists):
+        mock_exists.return_value = False
+        assert find_wifi_config_file() is None
+
+    @mock.patch("pi.wifi_provision._delete_file")
+    @mock.patch("pi.wifi_provision.connect_to_wifi")
+    @mock.patch("pi.wifi_provision._read_file")
+    @mock.patch("pi.wifi_provision.find_wifi_config_file")
+    def test_process_success(self, mock_find, mock_read, mock_connect, mock_delete):
+        mock_find.return_value = "/boot/printpulse-wifi.txt"
+        mock_read.return_value = "SSID=TestNet\nPASSWORD=secret"
+        mock_connect.return_value = (True, "Connected")
+        ok, msg = process_sd_card_config()
+        assert ok is True
+        mock_connect.assert_called_once_with("TestNet", "secret")
+        mock_delete.assert_called_once_with("/boot/printpulse-wifi.txt")
+
+    @mock.patch("pi.wifi_provision.find_wifi_config_file")
+    def test_process_no_file(self, mock_find):
+        mock_find.return_value = None
+        ok, msg = process_sd_card_config()
+        assert ok is False
+        assert "No SD card" in msg
+
+    @mock.patch("pi.wifi_provision._delete_file")
+    @mock.patch("pi.wifi_provision.connect_to_wifi")
+    @mock.patch("pi.wifi_provision._read_file")
+    @mock.patch("pi.wifi_provision.find_wifi_config_file")
+    def test_process_no_ssid(self, mock_find, mock_read, mock_connect, mock_delete):
+        mock_find.return_value = "/boot/printpulse-wifi.txt"
+        mock_read.return_value = "PASSWORD=secret"
+        ok, msg = process_sd_card_config()
+        assert ok is False
+        assert "no ssid" in msg.lower()
+
+    @mock.patch("pi.wifi_provision._delete_file")
+    @mock.patch("pi.wifi_provision.connect_to_wifi")
+    @mock.patch("pi.wifi_provision._read_file")
+    @mock.patch("pi.wifi_provision.find_wifi_config_file")
+    def test_file_deleted_on_failure(self, mock_find, mock_read, mock_connect, mock_delete):
+        mock_find.return_value = "/boot/printpulse-wifi.txt"
+        mock_read.return_value = "SSID=BadNet\nPASSWORD=wrong"
+        mock_connect.return_value = (False, "Auth failed")
+        ok, msg = process_sd_card_config()
+        assert ok is False
+        # File should still be deleted (contains credentials)
+        mock_delete.assert_called_once()
+
+
+# ── run_provisioning_check (boot orchestrator) ──────────────────────────────
+
+class TestRunProvisioningCheck:
+    @mock.patch("pi.wifi_provision.check_wifi_connected")
+    def test_already_connected(self, mock_connected):
+        mock_connected.return_value = True
+        assert run_provisioning_check() == WifiState.CONNECTED
+
+    @mock.patch("pi.wifi_provision.start_ap_mode")
+    @mock.patch("pi.wifi_provision.process_sd_card_config")
+    @mock.patch("pi.wifi_provision.check_wifi_connected")
+    def test_sd_card_success(self, mock_connected, mock_sd, mock_ap):
+        mock_connected.return_value = False
+        mock_sd.return_value = (True, "Connected via SD card")
+        assert run_provisioning_check() == WifiState.CONNECTED
+        mock_ap.assert_not_called()
+
+    @mock.patch("pi.wifi_provision.start_ap_mode")
+    @mock.patch("pi.wifi_provision.process_sd_card_config")
+    @mock.patch("pi.wifi_provision.check_wifi_connected")
+    def test_falls_through_to_ap(self, mock_connected, mock_sd, mock_ap):
+        mock_connected.return_value = False
+        mock_sd.return_value = (False, "No config")
+        mock_ap.return_value = True
+        assert run_provisioning_check() == WifiState.AP_MODE
+
+    @mock.patch("pi.wifi_provision.start_ap_mode")
+    @mock.patch("pi.wifi_provision.process_sd_card_config")
+    @mock.patch("pi.wifi_provision.check_wifi_connected")
+    def test_ap_mode_fails(self, mock_connected, mock_sd, mock_ap):
+        mock_connected.return_value = False
+        mock_sd.return_value = (False, "No config")
+        mock_ap.return_value = False
+        assert run_provisioning_check() == WifiState.FAILED


### PR DESCRIPTION
## Summary
- Adds first-boot WiFi provisioning: Pi creates `PrintPulse-Setup` hotspot with branded captive portal when no known network is available
- SD card fallback: drop `printpulse-wifi.txt` on boot partition for manual WiFi config
- "Reset WiFi" button in web UI to return to AP mode when moving to a new network
- `printpulse-wifi.service` systemd unit runs before web/watcher services to handle provisioning
- mDNS via avahi-daemon so the device is reachable at `printpulse.local`
- 48 unit tests covering state machine, config parsing, network scanning, AP mode, SD card provisioning, and boot orchestration
- Complete rewrite of Pi README with new OOBE-first getting started flow, SD card docs, WiFi troubleshooting

## Test plan
- [x] `ruff check` passes (0 errors)
- [x] `pytest tests/` passes (214 tests, including 48 new WiFi provisioning tests)
- [ ] CI passes on GitHub Actions
- [ ] Manual test on Pi Zero 2 W: boot with no WiFi → AP mode activates → phone connects → captive portal works → Pi joins home network

Fixes #47, Fixes #48, Fixes #49, Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)