### PR TITLE
feat: quiet wake mode — print latest only or all queued

### DIFF
--- a/pi/appliance.py
+++ b/pi/appliance.py
@@ -27,6 +27,7 @@ def default_config() -> dict:
         "quiet_enabled": True,
         "quiet_start": "22:00",
         "quiet_end": "08:00",
+        "quiet_wake_mode": "latest",
         "enabled": True,
         "auth_user": "",
         "auth_hash": "",

--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -466,6 +466,11 @@ def validate_save_input(form) -> tuple[dict | None, list[str]]:
             if hh > 23 or mm > 59:
                 errors.append(f"{label} is not a valid time.")
 
+    quiet_wake_mode = form.get("quiet_wake_mode", "latest")
+    if quiet_wake_mode not in ("latest", "all"):
+        errors.append("Quiet wake mode must be 'latest' or 'all'.")
+        quiet_wake_mode = "latest"
+
     # --- Auto-update ---
     auto_update_enabled = form.get("auto_update_enabled") == "1"
     _valid_intervals = {1, 6, 12, 24}
@@ -504,6 +509,7 @@ def validate_save_input(form) -> tuple[dict | None, list[str]]:
         "quiet_enabled": quiet_enabled,
         "quiet_start": quiet_start,
         "quiet_end": quiet_end,
+        "quiet_wake_mode": quiet_wake_mode,
         "auto_update_enabled": auto_update_enabled,
         "auto_update_interval": auto_update_interval,
     }, []
@@ -616,6 +622,7 @@ def save():
     config["quiet_enabled"] = validated["quiet_enabled"]
     config["quiet_start"] = validated["quiet_start"]
     config["quiet_end"] = validated["quiet_end"]
+    config["quiet_wake_mode"] = validated["quiet_wake_mode"]
     config["auto_update_enabled"] = validated["auto_update_enabled"]
     config["auto_update_interval"] = validated["auto_update_interval"]
     save_config(config)

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -302,7 +302,14 @@
                                value="{{ config.quiet_end }}">
                     </div>
                 </div>
-                <div class="help">Printer stays silent between these hours. Articles queue and print when quiet hours end. Timezone: {{ timezone }}</div>
+                <div style="margin-top: 0.5rem;">
+                    <label for="quiet_wake_mode">When quiet hours end:</label>
+                    <select name="quiet_wake_mode" id="quiet_wake_mode">
+                        <option value="latest" {% if config.quiet_wake_mode == 'latest' %}selected{% endif %}>Print only the latest item per source</option>
+                        <option value="all" {% if config.quiet_wake_mode == 'all' %}selected{% endif %}>Print all queued items</option>
+                    </select>
+                </div>
+                <div class="help">Printer stays silent between these hours. Timezone: {{ timezone }}</div>
             </div>
         </div>
 

--- a/printpulse/app.py
+++ b/printpulse/app.py
@@ -140,6 +140,13 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Quiet hours end time (e.g. 08:00). Resume printing at this time.",
     )
+    parser.add_argument(
+        "--quiet-wake-mode",
+        choices=["latest", "all"],
+        default="latest",
+        help="What to print when quiet hours end: 'latest' prints only the most "
+             "recent item per source (default), 'all' prints every queued item.",
+    )
     # ── Letter mode ──
     parser.add_argument(
         "--letter",
@@ -498,6 +505,7 @@ def run(argv: list[str]):
             theme=theme,
             quiet_start=args.quiet_start,
             quiet_end=args.quiet_end,
+            quiet_wake_mode=args.quiet_wake_mode,
         )
         return
 

--- a/printpulse/pi_launcher.py
+++ b/printpulse/pi_launcher.py
@@ -57,6 +57,8 @@ def main():
         quiet_start = config.get("quiet_start", "22:00")
         quiet_end = config.get("quiet_end", "08:00")
         argv.extend(["--quiet-start", quiet_start, "--quiet-end", quiet_end])
+        wake_mode = config.get("quiet_wake_mode", "latest")
+        argv.extend(["--quiet-wake-mode", wake_mode])
 
     print(f"PrintPulse appliance starting: {len(feeds)} feed(s), "
           f"interval={interval}s, max_prints={max_prints}")

--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -219,10 +219,23 @@ def _is_in_quiet_hours(quiet_start: str, quiet_end: str) -> bool:
         return now >= start or now < end
 
 
+def _filter_quiet_queue_latest(queue: list[dict]) -> list[dict]:
+    """Keep only the most recent item per source from the quiet queue.
+
+    Items later in the list are considered more recent (appended in arrival order).
+    """
+    latest_by_source: dict[str, dict] = {}
+    for item in queue:
+        source = item.get("_source", "")
+        latest_by_source[source] = item  # last one wins
+    return list(latest_by_source.values())
+
+
 def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                    plot_callback, theme: str = "green",
                    quiet_start: str | None = None,
-                   quiet_end: str | None = None):
+                   quiet_end: str | None = None,
+                   quiet_wake_mode: str = "latest"):
     """Main watch loop. Polls feeds and calls plot_callback(text) for each new item."""
     from rich.live import Live
     from rich.text import Text as RText
@@ -286,12 +299,16 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                 quiet_queue = _load_quiet_queue()
                 if quiet_queue and not (use_quiet and _is_in_quiet_hours(quiet_start, quiet_end)):
                     live.stop()
-                    ui.retro_panel(
-                        "QUIET QUEUE",
-                        f"Quiet hours ended — printing {len(quiet_queue)} saved item(s).",
-                        theme,
-                    )
                     _save_quiet_queue([])  # Clear before printing so a crash doesn't re-print
+                    if quiet_wake_mode == "latest":
+                        total_queued = len(quiet_queue)
+                        quiet_queue = _filter_quiet_queue_latest(quiet_queue)
+                        skipped = total_queued - len(quiet_queue)
+                        msg = (f"Quiet hours ended — printing {len(quiet_queue)} latest item(s)"
+                               f" ({skipped} older item(s) discarded).")
+                    else:
+                        msg = f"Quiet hours ended — printing {len(quiet_queue)} saved item(s)."
+                    ui.retro_panel("QUIET QUEUE", msg, theme)
                     for i, q_item in enumerate(quiet_queue, 1):
                         title = q_item["title"]
                         source = q_item.get("_source", "")

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -10,6 +10,7 @@ import pytest
 from printpulse.watch import (
     QUIET_QUEUE_FILE,
     _enqueue_quiet_items,
+    _filter_quiet_queue_latest,
     _is_in_quiet_hours,
     _load_quiet_queue,
     _save_quiet_queue,
@@ -149,3 +150,48 @@ class TestQuietQueue:
             f.write("not valid json{{{")
         monkeypatch.setattr("printpulse.watch.QUIET_QUEUE_FILE", bad_file)
         assert _load_quiet_queue() == []
+
+
+class TestFilterQuietQueueLatest:
+    """Test _filter_quiet_queue_latest keeps only the most recent item per source."""
+
+    def test_single_source_keeps_last(self):
+        queue = [
+            {"id": "1", "title": "Old", "summary": "", "_source": "Feed A"},
+            {"id": "2", "title": "Middle", "summary": "", "_source": "Feed A"},
+            {"id": "3", "title": "Latest", "summary": "", "_source": "Feed A"},
+        ]
+        result = _filter_quiet_queue_latest(queue)
+        assert len(result) == 1
+        assert result[0]["id"] == "3"
+        assert result[0]["title"] == "Latest"
+
+    def test_multiple_sources_keeps_latest_each(self):
+        queue = [
+            {"id": "a1", "title": "A old", "summary": "", "_source": "Feed A"},
+            {"id": "b1", "title": "B old", "summary": "", "_source": "Feed B"},
+            {"id": "a2", "title": "A new", "summary": "", "_source": "Feed A"},
+            {"id": "b2", "title": "B new", "summary": "", "_source": "Feed B"},
+        ]
+        result = _filter_quiet_queue_latest(queue)
+        assert len(result) == 2
+        titles = {r["title"] for r in result}
+        assert titles == {"A new", "B new"}
+
+    def test_empty_queue(self):
+        assert _filter_quiet_queue_latest([]) == []
+
+    def test_single_item(self):
+        queue = [{"id": "x", "title": "Only", "summary": "", "_source": "Src"}]
+        result = _filter_quiet_queue_latest(queue)
+        assert len(result) == 1
+        assert result[0]["id"] == "x"
+
+    def test_empty_source_treated_as_one_group(self):
+        queue = [
+            {"id": "1", "title": "First", "summary": "", "_source": ""},
+            {"id": "2", "title": "Second", "summary": "", "_source": ""},
+        ]
+        result = _filter_quiet_queue_latest(queue)
+        assert len(result) == 1
+        assert result[0]["id"] == "2"


### PR DESCRIPTION
## Summary
- Adds `quiet_wake_mode` option (`latest` or `all`) controlling what prints when quiet hours end
- **latest** (default): keeps only the most recent item per feed source, discards older queued items
- **all**: existing behavior — prints every item queued during quiet hours
- Configurable via CLI `--quiet-wake-mode`, appliance JSON config, and web UI dropdown

## Test plan
- [x] New `TestFilterQuietQueueLatest` test class with 5 tests covering single/multi source, empty queue, single item, empty source grouping
- [x] All 26 watch tests pass
- [x] Full test suite passes
- [x] Ruff lint clean

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)