### PR TITLE
fix: improve update log clarity and link version to update history

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -122,14 +122,21 @@ def _load_update_log() -> list[dict]:
     return []
 
 
-def _append_update_log(result: str, changed: bool):
-    """Append one entry to the update log and trim to max size."""
+def _append_update_log(result: str, changed: bool, *,
+                       status: str = "", description: str = ""):
+    """Append one entry to the update log and trim to max size.
+
+    status: "up_to_date", "updated", or "error"
+    description: brief summary of what changed (commit subjects) or error detail
+    """
     from datetime import datetime
     log = _load_update_log()
     log.append({
         "timestamp": datetime.now().strftime("%Y-%m-%d %I:%M:%S %p"),
         "result": result,
         "changed": changed,
+        "status": status or ("updated" if changed else "up_to_date"),
+        "description": description,
     })
     if len(log) > _UPDATE_LOG_MAX:
         log = log[-_UPDATE_LOG_MAX:]
@@ -140,11 +147,13 @@ def _append_update_log(result: str, changed: bool):
         logger.warning("Could not write update log: %s", exc)
 
 
-def _run_auto_update() -> tuple[str, bool]:
+def _run_auto_update() -> tuple[str, bool, str, str]:
     """Run git pull and, if new commits landed, restart services.
 
-    Returns (result_message, changed) where changed is True if
-    git pull fetched new commits.
+    Returns (result_message, changed, status, description) where:
+    - changed is True if git pull fetched new commits
+    - status is "up_to_date", "updated", or "error"
+    - description is a brief summary of what changed or error detail
     """
     global _APP_VERSION
 
@@ -160,12 +169,30 @@ def _run_auto_update() -> tuple[str, bool]:
     except (OSError, subprocess.TimeoutExpired) as exc:
         msg = f"git pull failed: {type(exc).__name__}"
         logger.error("Auto-update %s", msg)
-        return msg, False
+        return msg, False, "error", str(exc)
 
     changed = "already up to date" not in pull_output.lower()
 
     if not changed:
-        return "Already up to date.", False
+        return "Already up to date.", False, "up_to_date", ""
+
+    # Capture commit summaries for the description
+    description = ""
+    try:
+        log_result = subprocess.run(
+            ["git", "-C", _project_root, "log", "--oneline", "-5", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if log_result.returncode == 0 and log_result.stdout.strip():
+            # Take just the subject lines (drop the hash prefix)
+            subjects = []
+            for line in log_result.stdout.strip().splitlines()[:5]:
+                parts = line.split(" ", 1)
+                if len(parts) == 2:
+                    subjects.append(parts[1])
+            description = "; ".join(subjects) if subjects else pull_output
+    except Exception:
+        description = pull_output
 
     # New commits — restart services
     msgs = [f"git pull: {pull_output}"]
@@ -189,7 +216,7 @@ def _run_auto_update() -> tuple[str, bool]:
         msgs.append(f"printpulse-web: restart failed ({type(exc).__name__})")
         logger.error("Auto-update failed to restart printpulse-web: %s", exc)
 
-    return " | ".join(msgs), True
+    return " | ".join(msgs), True, "updated", description
 
 
 def _auto_update_worker():
@@ -213,12 +240,13 @@ def _auto_update_worker():
             check_ts = datetime.now().strftime("%Y-%m-%d %I:%M:%S %p")
             logger.info("Auto-update: running scheduled check")
 
-            result_msg, changed = _run_auto_update()
+            result_msg, changed, status, description = _run_auto_update()
 
             _auto_update_state["last_check"] = check_ts
             _auto_update_state["last_result"] = result_msg
             _auto_update_state["last_changed"] = changed
-            _append_update_log(result_msg, changed)
+            _append_update_log(result_msg, changed,
+                               status=status, description=description)
         except Exception as exc:
             logger.error("Auto-update worker error: %s", exc)
 

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -369,7 +369,7 @@
     </div>
 
     <div class="footer">
-        PrintPulse v{{ version }} &mdash; Raspberry Pi Zero
+        <a href="/update_log" style="color:var(--border); text-decoration:none;" title="View update history">PrintPulse v{{ version }}</a> &mdash; Raspberry Pi Zero
     </div>
 
     <!-- Live status polling -->

--- a/pi/webapp/templates/update_log.html
+++ b/pi/webapp/templates/update_log.html
@@ -82,8 +82,10 @@
             word-break: break-word;
         }
 
-        .changed-yes { color: var(--primary); }
-        .changed-no  { color: var(--mid); }
+        .status-updated    { color: var(--primary); font-weight: bold; }
+        .status-up-to-date { color: var(--mid); }
+        .status-error      { color: #ff4444; }
+        .description       { color: var(--mid); font-size: 0.8em; }
 
         .empty {
             color: var(--help);
@@ -117,18 +119,20 @@
             <thead>
                 <tr>
                     <th>Timestamp</th>
-                    <th>Updated?</th>
-                    <th>Result</th>
+                    <th>Status</th>
+                    <th>Description</th>
                 </tr>
             </thead>
             <tbody>
                 {% for item in items %}
                 <tr>
                     <td style="white-space:nowrap; color:var(--mid);">{{ item.timestamp }}</td>
-                    <td class="{% if item.changed %}changed-yes{% else %}changed-no{% endif %}">
-                        {% if item.changed %}YES{% else %}no{% endif %}
+                    <td class="{% if item.get('status', '') == 'updated' %}status-updated{% elif item.get('status', '') == 'error' %}status-error{% else %}status-up-to-date{% endif %}">
+                        {% if item.get('status', '') == 'updated' %}Updated
+                        {% elif item.get('status', '') == 'error' %}Error
+                        {% else %}Up to date{% endif %}
                     </td>
-                    <td>{{ item.result }}</td>
+                    <td>{% if item.get('description') %}{{ item.description }}{% elif item.get('status', '') == 'error' %}{{ item.result }}{% else %}&mdash;{% endif %}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -180,17 +180,29 @@ class TestAutoUpdateRoutes:
         assert resp.status_code == 200
         assert b"UPDATE" in resp.data
 
+    def test_update_log_backward_compat_old_entries(self):
+        """Old log entries without status/description should render gracefully."""
+        client = _make_client()
+        old_entry = {"timestamp": "2026-03-20 09:00:00 AM", "result": "Already up to date.", "changed": False}
+        with patch("pi.webapp.server._load_update_log", return_value=[old_entry]):
+            resp = client.get("/update_log")
+        assert resp.status_code == 200
+        assert b"Up to date" in resp.data
+
     def test_update_log_shows_entries(self):
         client = _make_client()
         fake_log = [
-            {"timestamp": "2026-03-23 10:00:00 AM", "result": "Already up to date.", "changed": False},
-            {"timestamp": "2026-03-23 11:00:00 AM", "result": "git pull: 1 file changed", "changed": True},
+            {"timestamp": "2026-03-23 10:00:00 AM", "result": "Already up to date.",
+             "changed": False, "status": "up_to_date", "description": ""},
+            {"timestamp": "2026-03-23 11:00:00 AM", "result": "git pull: 1 file changed",
+             "changed": True, "status": "updated", "description": "feat: add new feature"},
         ]
         with patch("pi.webapp.server._load_update_log", return_value=fake_log):
             resp = client.get("/update_log")
         assert resp.status_code == 200
-        assert b"Already up to date" in resp.data
-        assert b"1 file changed" in resp.data
+        assert b"Up to date" in resp.data
+        assert b"Updated" in resp.data
+        assert b"feat: add new feature" in resp.data
 
 
 class TestRunAutoUpdate:
@@ -200,8 +212,9 @@ class TestRunAutoUpdate:
         from pi.webapp.server import _run_auto_update
         mock_result = type("R", (), {"returncode": 0, "stdout": "Already up to date.\n", "stderr": ""})()
         with patch("subprocess.run", return_value=mock_result):
-            msg, changed = _run_auto_update()
+            msg, changed, status, description = _run_auto_update()
         assert changed is False
+        assert status == "up_to_date"
         assert "up to date" in msg.lower()
 
     def test_new_commits_triggers_restart(self):
@@ -212,7 +225,12 @@ class TestRunAutoUpdate:
             "stderr": "",
         })()
         restart_result = type("R", (), {"returncode": 0})()
-        call_results = [pull_result, restart_result]
+        log_result = type("R", (), {
+            "returncode": 0,
+            "stdout": "abc1234 feat: add cool feature\ndef5678 fix: repair widget",
+            "stderr": "",
+        })()
+        call_results = [pull_result, log_result, restart_result]
         popen_calls = []
 
         def fake_run(cmd, **kwargs):
@@ -223,14 +241,17 @@ class TestRunAutoUpdate:
 
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen):
-            msg, changed = _run_auto_update()
+            msg, changed, status, description = _run_auto_update()
 
         assert changed is True
+        assert status == "updated"
+        assert "feat: add cool feature" in description
         assert len(popen_calls) == 1  # printpulse-web restart via Popen
 
     def test_git_pull_failure(self):
         from pi.webapp.server import _run_auto_update
         with patch("subprocess.run", side_effect=OSError("not found")):
-            msg, changed = _run_auto_update()
+            msg, changed, status, description = _run_auto_update()
         assert changed is False
+        assert status == "error"
         assert "failed" in msg.lower()


### PR DESCRIPTION
## Summary
- Replace confusing "Updated? no" column with clear **Status** labels: `Up to date`, `Updated`, `Error` — color-coded appropriately
- Add **Description** column showing commit subject lines when an update is applied
- Version number in web UI footer now links to `/update_log` for easy access
- Backward-compatible with old log entries (graceful fallback for missing fields)

## Test plan
- [x] All 18 server tests pass including new backward-compat test
- [x] Full test suite passes
- [x] Ruff lint clean
- [x] Old log entries without `status`/`description` fields render gracefully

Fixes #57, fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)