### PR TITLE
Add reprint button for history items

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -35,7 +35,7 @@ if _project_root not in sys.path:
 
 from flask import (
     Flask, render_template, request, redirect, url_for, jsonify,
-    session, abort, g,
+    session, abort, flash, get_flashed_messages, g,
 )
 from pi.appliance import load_config, save_config, verify_password
 
@@ -787,6 +787,52 @@ def test_print():
     if ok:
         return jsonify({"ok": True, "message": "Test print sent successfully."})
     return jsonify({"ok": False, "message": "Print failed — check printer connection."})
+
+
+@app.route("/reprint", methods=["POST"])
+@require_auth
+def reprint():
+    """Reprint a history item by index."""
+    client_ip = request.remote_addr or "unknown"
+    if _check_rate_limit(f"reprint:{client_ip}"):
+        flash("Rate limit exceeded. Try again shortly.", "error")
+        return redirect(url_for("history"))
+
+    from printpulse.watch import load_history
+    from printpulse.thermal import print_news_item
+
+    try:
+        idx = int(request.form.get("index", -1))
+    except (ValueError, TypeError):
+        flash("Invalid item index.", "error")
+        return redirect(url_for("history"))
+
+    items = load_history()
+    items.reverse()  # newest first, matching display order
+
+    if idx < 0 or idx >= len(items):
+        flash("History item not found.", "error")
+        return redirect(url_for("history"))
+
+    item = items[idx]
+    from datetime import datetime
+    timestamp = datetime.now().strftime("%Y-%m-%d %I:%M:%S %p")
+
+    ok = print_news_item(
+        title=item.get("title", "Untitled"),
+        summary="(reprint from history)",
+        source=item.get("source", ""),
+        timestamp=timestamp,
+    )
+
+    if ok:
+        logger.info("Reprint requested for item %d: %s — success", idx, item.get("title", ""))
+        flash("Reprint sent to printer.", "success")
+    else:
+        logger.warning("Reprint requested for item %d: %s — failed", idx, item.get("title", ""))
+        flash("Reprint failed — check printer connection.", "error")
+
+    return redirect(url_for("history"))
 
 
 @app.route("/status")

--- a/pi/webapp/templates/history.html
+++ b/pi/webapp/templates/history.html
@@ -64,6 +64,29 @@
             color: var(--primary);
         }
 
+        .flash-messages {
+            max-width: 600px;
+            margin: 0 auto 15px auto;
+        }
+
+        .flash {
+            padding: 10px 14px;
+            margin-bottom: 8px;
+            border: 1px solid var(--border);
+            font-size: 0.85em;
+            background: #0d0d0d;
+        }
+
+        .flash-success {
+            color: var(--primary);
+            border-color: var(--mid);
+        }
+
+        .flash-error {
+            color: #ff4444;
+            border-color: #662222;
+        }
+
         .panel {
             border: 2px solid var(--border);
             padding: 20px;
@@ -82,10 +105,19 @@
         .history-item {
             padding: 8px 0;
             border-bottom: 1px solid #111;
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 10px;
         }
 
         .history-item:last-child {
             border-bottom: none;
+        }
+
+        .history-info {
+            flex: 1;
+            min-width: 0;
         }
 
         .history-title {
@@ -97,6 +129,35 @@
             color: var(--help);
             font-size: 0.75em;
             margin-top: 2px;
+        }
+
+        .reprint-form {
+            flex-shrink: 0;
+        }
+
+        .reprint-btn {
+            background: transparent;
+            color: var(--mid);
+            border: 1px solid var(--border);
+            padding: 4px 10px;
+            font-family: 'Courier New', monospace;
+            font-size: 0.75em;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: color 0.15s, border-color 0.15s, text-shadow 0.15s;
+        }
+
+        .reprint-btn:hover {
+            color: var(--primary);
+            border-color: var(--primary);
+            text-shadow: 0 0 6px var(--glow);
+        }
+
+        .reprint-btn:disabled {
+            color: var(--dim);
+            border-color: #111;
+            cursor: not-allowed;
+            text-shadow: none;
         }
 
         .empty {
@@ -118,15 +179,32 @@
     <div class="subtitle">Print History</div>
     <div class="nav"><a href="/">&laquo; Back to Configuration</a></div>
 
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="flash-messages">
+        {% for category, message in messages %}
+        <div class="flash flash-{{ category }}">{{ message }}</div>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+
     <div class="panel">
         <div class="panel-title">// RECENTLY PRINTED (showing {{ items|length }} of {{ total }})</div>
         {% if items %}
             {% for item in items %}
             <div class="history-item">
-                <div class="history-title">&gt; {{ item.title }}</div>
-                <div class="history-meta">
-                    {% if item.source %}{{ item.source }} &mdash; {% endif %}{{ item.timestamp }}
+                <div class="history-info">
+                    <div class="history-title">&gt; {{ item.title }}</div>
+                    <div class="history-meta">
+                        {% if item.source %}{{ item.source }} &mdash; {% endif %}{{ item.timestamp }}
+                    </div>
                 </div>
+                <form class="reprint-form" method="post" action="/reprint">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <input type="hidden" name="index" value="{{ loop.index0 }}">
+                    <button type="submit" class="reprint-btn" title="Reprint this item">[REPRINT]</button>
+                </form>
             </div>
             {% endfor %}
         {% else %}


### PR DESCRIPTION
## Summary
- Adds a `[REPRINT]` button next to each item on the print history page
- New `/reprint` POST route that looks up a history item by display index and sends it to the thermal printer via `print_news_item`
- Flash message feedback (success/error) styled in the existing retro terminal aesthetic
- Includes rate limiting, CSRF protection, and index bounds validation

Closes #61

## Test plan
- [ ] Navigate to `/history` and verify each item shows a `[REPRINT]` button
- [ ] Click a reprint button and verify the flash message appears (success or error depending on printer)
- [ ] Verify the button styling matches the green/amber theme
- [ ] Verify CSRF token is included in the form
- [ ] Verify invalid/out-of-range index is handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)