### PR TITLE
Fix update log: blank description and unhelpful status field

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -137,6 +137,7 @@ def _append_update_log(result: str, changed: bool, *,
         "changed": changed,
         "status": status or ("updated" if changed else "up_to_date"),
         "description": description,
+        "version": _APP_VERSION,
     })
     if len(log) > _UPDATE_LOG_MAX:
         log = log[-_UPDATE_LOG_MAX:]
@@ -706,39 +707,16 @@ def update():
     if _check_rate_limit(f"update:{client_ip}"):
         abort(429)
 
-    results = []
+    result_msg, changed, status, description = _run_auto_update()
 
-    # Git pull
-    try:
-        result = subprocess.run(
-            ["git", "-C", _project_root, "pull", "--ff-only"],
-            capture_output=True, text=True, timeout=30,
-        )
-        pull_output = result.stdout.strip()
-        if result.returncode != 0:
-            pull_output = result.stderr.strip() or "git pull failed"
-        results.append(f"git pull: {pull_output}")
-        logger.info("Update git pull: %s", pull_output)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        results.append(f"git pull failed: {type(exc).__name__}")
-        logger.error("Update git pull failed: %s", type(exc).__name__)
+    # Prefix description to indicate this was a manual update
+    if description:
+        description = f"(manual) {description}"
+    else:
+        description = "(manual update)"
 
-    # Restart services
-    for svc in ["printpulse", "printpulse-web"]:
-        try:
-            subprocess.run(
-                ["sudo", "systemctl", "restart", svc],
-                timeout=10,
-            )
-            results.append(f"{svc}: restarted")
-            logger.info("Update restarted %s", svc)
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            results.append(f"{svc}: restart failed ({type(exc).__name__})")
-            logger.error("Update failed to restart %s: %s", svc, type(exc).__name__)
-
-    # Refresh version after update
-    global _APP_VERSION
-    _APP_VERSION = _get_version_info()
+    _append_update_log(result_msg, changed, status=status,
+                       description=description)
 
     return redirect(url_for("index"))
 
@@ -864,6 +842,29 @@ def toggle_enabled():
     return redirect(url_for("index"))
 
 
+def _get_recent_commits(count: int = 10) -> list[dict]:
+    """Get recent git commits as a list of dicts with hash, subject, date."""
+    commits = []
+    try:
+        result = subprocess.run(
+            ["git", "-C", _project_root, "log",
+             f"-{count}", "--format=%h|%s|%ci"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.strip().splitlines():
+                parts = line.split("|", 2)
+                if len(parts) == 3:
+                    commits.append({
+                        "hash": parts[0],
+                        "subject": parts[1],
+                        "date": parts[2],
+                    })
+    except Exception:
+        pass
+    return commits
+
+
 @app.route("/update_log")
 @require_auth
 def update_log():
@@ -871,11 +872,13 @@ def update_log():
     items = _load_update_log()
     items = list(reversed(items))  # newest first
     config = load_config()
+    recent_commits = _get_recent_commits()
     return render_template(
         "update_log.html",
         items=items,
         config=config,
         version=_APP_VERSION,
+        recent_commits=recent_commits,
     )
 
 

--- a/pi/webapp/templates/update_log.html
+++ b/pi/webapp/templates/update_log.html
@@ -85,7 +85,21 @@
         .status-updated    { color: var(--primary); font-weight: bold; }
         .status-up-to-date { color: var(--mid); }
         .status-error      { color: #ff4444; }
-        .description       { color: var(--mid); font-size: 0.8em; }
+
+        .commit-hash {
+            color: var(--mid);
+            font-size: 0.85em;
+        }
+
+        .commit-subject {
+            color: var(--primary);
+        }
+
+        .commit-date {
+            color: var(--help);
+            font-size: 0.8em;
+            white-space: nowrap;
+        }
 
         .empty {
             color: var(--help);
@@ -113,24 +127,52 @@
     <div class="subtitle">Auto-Update Log</div>
 
     <div class="panel">
-        <div class="panel-title">// UPDATE HISTORY</div>
+        <div class="panel-title">// RECENT COMMITS</div>
+        {% if recent_commits %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Hash</th>
+                    <th>Message</th>
+                    <th>Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for commit in recent_commits %}
+                <tr>
+                    <td class="commit-hash">{{ commit.hash }}</td>
+                    <td class="commit-subject">{{ commit.subject }}</td>
+                    <td class="commit-date">{{ commit.date }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <div class="empty">No git history available.</div>
+        {% endif %}
+    </div>
+
+    <div class="panel">
+        <div class="panel-title">// UPDATE CHECK HISTORY</div>
         {% if items %}
         <table>
             <thead>
                 <tr>
                     <th>Timestamp</th>
-                    <th>Status</th>
-                    <th>Description</th>
+                    <th>Version</th>
+                    <th>Result</th>
+                    <th>Details</th>
                 </tr>
             </thead>
             <tbody>
                 {% for item in items %}
                 <tr>
                     <td style="white-space:nowrap; color:var(--mid);">{{ item.timestamp }}</td>
+                    <td style="white-space:nowrap;" class="commit-hash">{{ item.get('version', '') or '&mdash;' }}</td>
                     <td class="{% if item.get('status', '') == 'updated' %}status-updated{% elif item.get('status', '') == 'error' %}status-error{% else %}status-up-to-date{% endif %}">
                         {% if item.get('status', '') == 'updated' %}Updated
                         {% elif item.get('status', '') == 'error' %}Error
-                        {% else %}Up to date{% endif %}
+                        {% else %}No changes{% endif %}
                     </td>
                     <td>{% if item.get('description') %}{{ item.description }}{% elif item.get('status', '') == 'error' %}{{ item.result }}{% else %}&mdash;{% endif %}</td>
                 </tr>


### PR DESCRIPTION
## Summary
- Fixed blank description in update log entries by showing current version for "no changes" checks and commit summaries for updates
- Replaced unhelpful "Up to date" status column with a "Version" column showing the app version at time of each check, and renamed status to "No changes" for clarity
- Added a "Recent Commits" panel to the update log page showing the last 10 git commits with hashes, messages, and dates
- Made the manual "Update" button properly log to the update history (it was previously unlogged)
- Refactored manual update route to reuse `_run_auto_update()`, eliminating code duplication

## Test plan
- [ ] Trigger an auto-update check and verify the log entry shows version and description
- [ ] Click the manual "Update" button and verify a "(manual)" prefixed entry appears in the update log
- [ ] Visit `/update_log` and verify the "Recent Commits" panel shows git history
- [ ] Verify the "Version" column displays version strings for new entries and `—` for legacy entries without version info

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)