### PR TITLE
security: comprehensive security hardening for LAN web UI

### DIFF
--- a/pi/appliance.py
+++ b/pi/appliance.py
@@ -11,6 +11,9 @@ import secrets
 
 from printpulse.secure_fs import secure_write_json
 
+# PBKDF2 iterations — OWASP 2023 recommends >= 600,000 for SHA-256
+_PBKDF2_ITERATIONS = 600_000
+
 CONFIG_PATH = os.path.expanduser("~/.printpulse_appliance.json")
 
 
@@ -58,22 +61,48 @@ def save_config(data: dict) -> None:
 
 
 def hash_password(password: str) -> str:
-    """Hash a password with a random salt using SHA-256.
+    """Hash a password using PBKDF2-HMAC-SHA256 with a random salt.
 
-    Returns 'salt:hash' string for storage.
+    Returns 'pbkdf2:iterations:salt:hash' string for storage.
+    Previous format ('salt:sha256hash') is still accepted by verify_password
+    for backward compatibility, but new hashes always use PBKDF2.
     """
     salt = secrets.token_hex(16)
-    h = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
-    return f"{salt}:{h}"
+    h = hashlib.pbkdf2_hmac(
+        "sha256", password.encode(), salt.encode(), _PBKDF2_ITERATIONS,
+    ).hex()
+    return f"pbkdf2:{_PBKDF2_ITERATIONS}:{salt}:{h}"
 
 
 def verify_password(password: str, stored_hash: str) -> bool:
-    """Verify a password against a stored 'salt:hash' string."""
-    if ":" not in stored_hash:
+    """Verify a password against a stored hash string.
+
+    Supports both the new PBKDF2 format ('pbkdf2:iterations:salt:hash')
+    and the legacy SHA-256 format ('salt:sha256hash') for backward
+    compatibility with existing config files.
+    """
+    if not stored_hash or ":" not in stored_hash:
         return False
-    salt, expected = stored_hash.split(":", 1)
-    h = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
-    return secrets.compare_digest(h, expected)
+
+    if stored_hash.startswith("pbkdf2:"):
+        # New PBKDF2 format
+        parts = stored_hash.split(":", 3)
+        if len(parts) != 4:
+            return False
+        _, iterations_str, salt, expected = parts
+        try:
+            iterations = int(iterations_str)
+        except ValueError:
+            return False
+        h = hashlib.pbkdf2_hmac(
+            "sha256", password.encode(), salt.encode(), iterations,
+        ).hex()
+        return secrets.compare_digest(h, expected)
+    else:
+        # Legacy SHA-256 format for backward compatibility
+        salt, expected = stored_hash.split(":", 1)
+        h = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
+        return secrets.compare_digest(h, expected)
 
 
 def generate_secret_key() -> str:

--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import secrets
+import socket
 import subprocess
 import sys
 import threading
@@ -93,9 +94,19 @@ def _get_version_info() -> str:
 
 _APP_VERSION = _get_version_info()
 
-# Load secret key from config (generated during setup)
+# Load secret key from config — generate and persist if missing
 _cfg = load_config()
-app.secret_key = _cfg.get("secret_key") or secrets.token_hex(32)
+if not _cfg.get("secret_key"):
+    _cfg["secret_key"] = secrets.token_hex(32)
+    save_config(_cfg)
+    logger.info("Generated and persisted new Flask secret key.")
+app.secret_key = _cfg["secret_key"]
+
+# Harden session cookies
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+# SESSION_COOKIE_SECURE is intentionally False — this is a LAN HTTP appliance
+app.config["SESSION_COOKIE_SECURE"] = False
 
 
 # ─── Auto-Update ────────────────────────────────────────────────────────────
@@ -260,22 +271,36 @@ _update_thread.start()
 # ─── Rate Limiting ──────────────────────────────────────────────────────────
 
 _rate_limit_store: dict[str, list[float]] = {}
+_RATE_LIMIT_STORE_MAX_KEYS = 256  # cap unique keys to bound memory
 RATE_LIMIT_MAX = 10       # max requests
 RATE_LIMIT_WINDOW = 60    # per 60 seconds
+LOGIN_RATE_LIMIT_MAX = 5  # stricter limit for login attempts
+LOGIN_RATE_LIMIT_WINDOW = 120  # per 2 minutes
 
 
-def _check_rate_limit(key: str) -> bool:
+def _check_rate_limit(key: str, max_requests: int = RATE_LIMIT_MAX,
+                      window: int = RATE_LIMIT_WINDOW) -> bool:
     """Return True if rate limit exceeded."""
     now = time.time()
+
+    # Evict stale keys periodically to prevent unbounded memory growth
+    if len(_rate_limit_store) > _RATE_LIMIT_STORE_MAX_KEYS:
+        stale_keys = [
+            k for k, timestamps in _rate_limit_store.items()
+            if not timestamps or now - timestamps[-1] > window
+        ]
+        for k in stale_keys:
+            del _rate_limit_store[k]
+
     if key not in _rate_limit_store:
         _rate_limit_store[key] = []
 
     # Remove old entries outside the window
     _rate_limit_store[key] = [
-        t for t in _rate_limit_store[key] if now - t < RATE_LIMIT_WINDOW
+        t for t in _rate_limit_store[key] if now - t < window
     ]
 
-    if len(_rate_limit_store[key]) >= RATE_LIMIT_MAX:
+    if len(_rate_limit_store[key]) >= max_requests:
         return True
 
     _rate_limit_store[key].append(now)
@@ -310,8 +335,10 @@ def login():
     error = None
     if request.method == "POST":
         client_ip = request.remote_addr or "unknown"
-        if _check_rate_limit(f"login:{client_ip}"):
-            error = "Too many attempts. Try again in a minute."
+        if _check_rate_limit(f"login:{client_ip}",
+                             max_requests=LOGIN_RATE_LIMIT_MAX,
+                             window=LOGIN_RATE_LIMIT_WINDOW):
+            error = "Too many attempts. Try again in a few minutes."
         else:
             cfg = load_config()
             username = request.form.get("username", "")
@@ -367,9 +394,15 @@ def _add_security_headers(response):
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
         "script-src 'self' 'unsafe-inline'; "
-        "style-src 'self' 'unsafe-inline';"
+        "style-src 'self' 'unsafe-inline'; "
+        "form-action 'self';"
     )
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+    # Prevent caching of authenticated HTML pages (not static assets)
+    if response.content_type and "text/html" in response.content_type:
+        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+        response.headers["Pragma"] = "no-cache"
     return response
 
 
@@ -399,7 +432,11 @@ _PRIVATE_NETWORKS = [
 
 
 def _is_private_hostname(hostname: str) -> bool:
-    """Check if a hostname resolves to a private/reserved IP."""
+    """Check if a hostname resolves to a private/reserved IP.
+
+    Performs actual DNS resolution to catch domain names that point to
+    private IPs (DNS rebinding / SSRF bypass).
+    """
     # Block obvious localhost aliases
     if hostname.lower() in ("localhost", "localhost.localdomain", "0.0.0.0"):
         return True
@@ -409,7 +446,23 @@ def _is_private_hostname(hostname: str) -> bool:
         addr = ipaddress.ip_address(hostname)
         return any(addr in net for net in _PRIVATE_NETWORKS)
     except ValueError:
-        pass  # Not a raw IP, could be a domain name — allow it
+        pass  # Not a raw IP — resolve it
+
+    # Resolve hostname and check all addresses
+    try:
+        addrinfos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC,
+                                       socket.SOCK_STREAM)
+        for family, _type, _proto, _canonname, sockaddr in addrinfos:
+            ip_str = sockaddr[0]
+            try:
+                addr = ipaddress.ip_address(ip_str)
+                if any(addr in net for net in _PRIVATE_NETWORKS):
+                    return True
+            except ValueError:
+                continue
+    except (socket.gaierror, OSError):
+        # DNS resolution failed — allow the URL (it will fail at fetch time)
+        pass
 
     return False
 

--- a/pi/webapp/wifi_routes.py
+++ b/pi/webapp/wifi_routes.py
@@ -11,11 +11,26 @@ from __future__ import annotations
 
 import logging
 
-from flask import Blueprint, render_template, request, redirect, jsonify
+from flask import Blueprint, render_template, request, redirect, jsonify, abort
 
 logger = logging.getLogger("printpulse.wifi_routes")
 
 wifi_bp = Blueprint("wifi", __name__)
+
+
+def _require_auth_for_reset():
+    """Check auth for the wifi reset endpoint (imported lazily to avoid circular imports)."""
+    from pi.webapp.server import _is_auth_configured, _check_rate_limit
+    from flask import session, redirect, url_for
+
+    if _is_auth_configured() and not session.get("authenticated"):
+        return redirect(url_for("login"))
+
+    client_ip = request.remote_addr or "unknown"
+    if _check_rate_limit(f"wifi_reset:{client_ip}"):
+        abort(429)
+
+    return None
 
 
 def _get_provision_module():
@@ -83,7 +98,14 @@ def wifi_connect():
 
 @wifi_bp.route("/wifi/reset", methods=["POST"])
 def wifi_reset():
-    """Drop back to AP mode (called from the main web UI)."""
+    """Drop back to AP mode (called from the main web UI).
+
+    Requires authentication since this is a destructive network operation.
+    """
+    auth_redirect = _require_auth_for_reset()
+    if auth_redirect is not None:
+        return auth_redirect
+
     prov = _get_provision_module()
     ok = prov["start_ap"]()
     if ok:

--- a/printpulse/secure_fs.py
+++ b/printpulse/secure_fs.py
@@ -27,21 +27,45 @@ def secure_makedirs(path: str, mode: int = _DIR_MODE) -> None:
 
 
 def secure_write_json(path: str, data, indent: int = 2) -> None:
-    """Write JSON to a file with secure permissions."""
+    """Write JSON to a file with secure permissions.
+
+    Uses atomic write (temp file + rename) to avoid partial writes on crash.
+    On Unix, the file is created with owner-only permissions from the start
+    (no TOCTOU window where the file is world-readable).
+    """
     import json
 
     dir_path = os.path.dirname(path)
     if dir_path:
         secure_makedirs(dir_path)
 
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=indent, ensure_ascii=False)
+    content = json.dumps(data, indent=indent, ensure_ascii=False)
 
     if _IS_UNIX:
+        # Open with restrictive permissions from the start (no chmod race)
+        fd = os.open(
+            path + ".tmp",
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            _FILE_MODE,
+        )
         try:
-            os.chmod(path, _FILE_MODE)
-        except OSError:
-            pass
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(path + ".tmp", path)
+        except BaseException:
+            # Clean up temp file on failure
+            try:
+                os.unlink(path + ".tmp")
+            except OSError:
+                pass
+            raise
+    else:
+        # Windows fallback — no atomic rename guarantees
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
 
 
 def secure_tempfile(suffix: str = ".tmp", prefix: str = "printpulse_") -> str:

--- a/tests/test_appliance.py
+++ b/tests/test_appliance.py
@@ -45,13 +45,15 @@ class TestDefaultConfig:
 
 
 class TestPasswordHashing:
-    def test_hash_produces_salt_colon_hash(self):
+    def test_hash_produces_pbkdf2_format(self):
         result = hash_password("test123")
-        assert ":" in result
-        parts = result.split(":", 1)
-        assert len(parts) == 2
-        assert len(parts[0]) == 32  # 16 bytes hex = 32 chars
-        assert len(parts[1]) == 64  # SHA-256 hex = 64 chars
+        assert result.startswith("pbkdf2:")
+        parts = result.split(":")
+        assert len(parts) == 4  # pbkdf2:iterations:salt:hash
+        assert parts[0] == "pbkdf2"
+        assert int(parts[1]) >= 600_000
+        assert len(parts[2]) == 32  # 16 bytes hex = 32 chars
+        assert len(parts[3]) == 64  # SHA-256 hex = 64 chars
 
     def test_verify_correct_password(self):
         hashed = hash_password("mypassword")
@@ -78,6 +80,16 @@ class TestPasswordHashing:
         h2 = hash_password("same")
         assert verify_password("same", h1) is True
         assert verify_password("same", h2) is True
+
+    def test_legacy_sha256_format_still_verifies(self):
+        """Existing configs with old SHA-256 hashes should still work."""
+        import hashlib
+        import secrets as _secrets
+        salt = _secrets.token_hex(16)
+        h = hashlib.sha256(f"{salt}:legacypass".encode()).hexdigest()
+        legacy_hash = f"{salt}:{h}"
+        assert verify_password("legacypass", legacy_hash) is True
+        assert verify_password("wrongpass", legacy_hash) is False
 
 
 class TestSecretKey:


### PR DESCRIPTION
## Summary

Comprehensive security review and hardening of the PrintPulse LAN web UI, addressing authentication, input validation, session management, and infrastructure concerns.

Closes #64

## Fixes Applied

### 1. Password Hashing (Critical)
- **Before:** SHA-256 with salt (single iteration -- trivially brute-forceable with modern GPUs)
- **After:** PBKDF2-HMAC-SHA256 with 600,000 iterations (OWASP 2023 recommendation)
- Backward compatible: existing SHA-256 hashes in config files still verify correctly
- New passwords always use PBKDF2 format (`pbkdf2:iterations:salt:hash`)

### 2. Secret Key Persistence (High)
- **Before:** If `secret_key` was empty in config, a new random key was generated on every server restart, invalidating all user sessions
- **After:** Generated key is persisted to config on first creation

### 3. Session Cookie Hardening (Medium)
- Added `SESSION_COOKIE_HTTPONLY = True` (prevents JavaScript access to session cookie)
- Added `SESSION_COOKIE_SAMESITE = "Lax"` (CSRF defense in depth)
- `SESSION_COOKIE_SECURE` intentionally `False` since this is HTTP-only LAN

### 4. Login Rate Limiting (Medium)
- **Before:** 10 attempts per 60 seconds (same as all other endpoints)
- **After:** 5 attempts per 120 seconds for login specifically

### 5. Rate Limit Memory Eviction (Low)
- **Before:** `_rate_limit_store` dict could grow unboundedly with unique IP keys
- **After:** Stale keys are evicted when store exceeds 256 entries

### 6. SSRF Feed URL Bypass Fix (Medium)
- **Before:** `_is_private_hostname()` only checked raw IP addresses and literal "localhost" -- a domain like `evil.com` resolving to `192.168.1.1` would bypass the check
- **After:** Performs actual DNS resolution via `socket.getaddrinfo()` and checks all resolved addresses against private ranges

### 7. Atomic File Writes / TOCTOU Fix (Medium)
- **Before:** `secure_write_json()` wrote the file then called `os.chmod()` -- brief window where file was world-readable
- **After:** Uses `os.open()` with restrictive mode bits from creation, writes to `.tmp`, then does atomic `os.replace()`

### 8. WiFi Reset Auth + Rate Limiting (Medium)
- **Before:** `/wifi/reset` POST endpoint had no authentication or rate limiting -- any device on the LAN could trigger AP mode
- **After:** Requires authentication and applies rate limiting

### 9. Security Headers (Low)
- Added `form-action 'self'` to CSP (prevents form submissions to external origins)
- Added `Permissions-Policy: camera=(), microphone=(), geolocation=()` 
- Added `Cache-Control: no-store` and `Pragma: no-cache` on HTML responses to prevent caching of authenticated content

## Design Notes (Not Fixed -- Low Risk for LAN Appliance)

- **`unsafe-inline` in CSP:** The inline `<script>` and `<style>` blocks in templates would need to be refactored to external files to remove this. Low risk on a LAN appliance with no user-generated content and Jinja2 auto-escaping.
- **`/logout` is GET:** Could be triggered by an attacker embedding `<img src="/logout">`. Very low impact (forces re-login) and low risk on LAN.
- **No HTTPS / HSTS:** This is an HTTP-only LAN appliance. Adding TLS would require self-signed certs and mDNS complexity that is out of scope.
- **`subprocess` calls are safe:** All `subprocess.run` calls use list arguments (no shell=True) with hardcoded command strings. User input never flows into command arguments. The git, systemctl, and nmcli commands use fixed argument patterns.
- **Dependencies:** `feedparser>=6.0` already includes XXE protection. `flask>=3.0` is current. No known CVEs in pinned ranges.

## Test plan
- [x] All 30 `test_appliance.py` tests pass (including new legacy hash compat test)
- [x] All 20 `test_secure_fs.py` tests pass
- [x] All 52 validation + server tests pass
- [ ] Manual: verify login works with existing password after upgrade
- [ ] Manual: verify new password hashing produces PBKDF2 format
- [ ] Manual: verify session survives server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)