### PR TITLE
feat: add 'next' quiet wake mode — print oldest queued item only

### DIFF
--- a/pi/webapp/server.py
+++ b/pi/webapp/server.py
@@ -552,8 +552,8 @@ def validate_save_input(form) -> tuple[dict | None, list[str]]:
                 errors.append(f"{label} is not a valid time.")
 
     quiet_wake_mode = form.get("quiet_wake_mode", "latest")
-    if quiet_wake_mode not in ("latest", "all"):
-        errors.append("Quiet wake mode must be 'latest' or 'all'.")
+    if quiet_wake_mode not in ("latest", "all", "next"):
+        errors.append("Quiet wake mode must be 'latest', 'all', or 'next'.")
         quiet_wake_mode = "latest"
 
     # --- Auto-update ---

--- a/pi/webapp/templates/index.html
+++ b/pi/webapp/templates/index.html
@@ -311,6 +311,7 @@
                     <label for="quiet_wake_mode">When quiet hours end:</label>
                     <select name="quiet_wake_mode" id="quiet_wake_mode">
                         <option value="latest" {% if config.quiet_wake_mode == 'latest' %}selected{% endif %}>Print only the latest item per source</option>
+                        <option value="next" {% if config.quiet_wake_mode == 'next' %}selected{% endif %}>Print next item only (oldest queued)</option>
                         <option value="all" {% if config.quiet_wake_mode == 'all' %}selected{% endif %}>Print all queued items</option>
                     </select>
                 </div>

--- a/printpulse/app.py
+++ b/printpulse/app.py
@@ -142,10 +142,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--quiet-wake-mode",
-        choices=["latest", "all"],
+        choices=["latest", "all", "next"],
         default="latest",
         help="What to print when quiet hours end: 'latest' prints only the most "
-             "recent item per source (default), 'all' prints every queued item.",
+             "recent item per source (default), 'all' prints every queued item, "
+             "'next' prints only the oldest queued item.",
     )
     # ── Letter mode ──
     parser.add_argument(

--- a/printpulse/watch.py
+++ b/printpulse/watch.py
@@ -299,14 +299,21 @@ def run_watch_loop(feed_urls: list[str], interval: int, max_prints: int,
                 quiet_queue = _load_quiet_queue()
                 if quiet_queue and not (use_quiet and _is_in_quiet_hours(quiet_start, quiet_end)):
                     live.stop()
-                    _save_quiet_queue([])  # Clear before printing so a crash doesn't re-print
                     if quiet_wake_mode == "latest":
+                        _save_quiet_queue([])  # Clear entire queue
                         total_queued = len(quiet_queue)
                         quiet_queue = _filter_quiet_queue_latest(quiet_queue)
                         skipped = total_queued - len(quiet_queue)
                         msg = (f"Quiet hours ended — printing {len(quiet_queue)} latest item(s)"
                                f" ({skipped} older item(s) discarded).")
+                    elif quiet_wake_mode == "next":
+                        # Print only the oldest item, keep the rest queued
+                        quiet_queue, remaining = quiet_queue[:1], quiet_queue[1:]
+                        _save_quiet_queue(remaining)
+                        msg = (f"Quiet hours ended — printing next item"
+                               f" ({len(remaining)} still queued).")
                     else:
+                        _save_quiet_queue([])  # Clear entire queue
                         msg = f"Quiet hours ended — printing {len(quiet_queue)} saved item(s)."
                     ui.retro_panel("QUIET QUEUE", msg, theme)
                     for i, q_item in enumerate(quiet_queue, 1):


### PR DESCRIPTION
## Summary
- Adds a third quiet wake mode option: **"Print next item only (oldest queued)"**
- When selected, only the oldest item in the queue is printed when quiet hours end; remaining items stay queued for subsequent poll cycles
- Default remains "Print only the latest item per source" (no breaking change)
- Updated CLI, web UI dropdown, and server validation

## Test plan
- [x] All 226 existing tests pass
- [x] Ruff lint clean
- [ ] Verify "Print next item only" option appears in web UI dropdown
- [ ] Verify queue drains one item at a time across poll cycles

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)